### PR TITLE
feat: extend kick sound with click and pitch envelope

### DIFF
--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -1,15 +1,40 @@
 import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
+import { Noise } from "./noise";
 
 export const makeKick = (ctx: AudioContext, freq1: number, freq2: number) => {
   const inst = new Instrument(ctx);
 
   const osc1 = new Oscillator(ctx, freq1);
-
   const osc2 = new Oscillator(ctx, freq2);
+
+  // Add pitch envelopes to the tonal oscillators
+  osc1.setPitchADSR({
+    attack: 0.005, // Very quick attack
+    decay: 0.1, // Fast decay to create the pitch drop
+    sustain: 0, // No sustain - typical for kick drums
+    release: 0.05, // Quick release
+  });
+
+  osc2.setPitchADSR({
+    attack: 0.005, // Very quick attack
+    decay: 0.08, // Slightly faster decay for the main oscillator
+    sustain: 0, // No sustain - typical for kick drums
+    release: 0.05, // Quick release
+  });
+
+  // Add short "click" sound using noise generator
+  const clickNoise = new Noise(ctx);
+  clickNoise.setADSR({
+    attack: 0.001, // Extremely quick attack for sharp click
+    decay: 0.01, // Very short decay
+    sustain: 0, // No sustain
+    release: 0.005, // Very quick release
+  });
 
   inst.addGenerator("sub", osc1);
   inst.addGenerator("main", osc2);
+  inst.addGenerator("click", clickNoise);
 
   return inst;
 };


### PR DESCRIPTION
Extend kick sound with short "click" sound and pitch envelope on tonal sound

## Changes
- Add short click sound using noise generator with sharp ADSR envelope
- Add pitch envelopes to both oscillators for characteristic kick drum pitch drop
- Follow existing code conventions using Noise and Oscillator classes

Closes #5

Generated with [Claude Code](https://claude.ai/code)