### PR TITLE
Add hihat instrument with debug UI button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useLibGooey } from "@/package/src/libgooey";
 import { makeKick } from "@/package/src/kick";
 import { makeSnare } from "@/package/src/snare";
-import { makeClosedHiHat } from "@/package/src/hihat";
+import { makeClosedHiHat, makeOpenHiHat } from "@/package/src/hihat";
 
 export default function ReactTestPage() {
   const { audioContext, isLoaded, isLoading, error, initialize, stage } =
@@ -52,20 +52,37 @@ export default function ReactTestPage() {
     }
   };
 
-  const triggerHiHat = () => {
+  const triggerClosedHiHat = () => {
     const ctx = audioContext;
     if (ctx && stage) {
       // TODO
       // shouldn't make this on every click
-      const hihat1 = makeClosedHiHat(ctx);
+      const closedHihat = makeClosedHiHat(ctx);
 
-      stage.addInstrument("hihat", hihat1);
+      stage.addInstrument("closedHihat", closedHihat);
 
       // TODO
       // allow trigger of n names
-      stage.trigger("hihat");
+      stage.trigger("closedHihat");
 
-      console.log("HiHat triggered!");
+      console.log("Closed HiHat triggered!");
+    }
+  };
+
+  const triggerOpenHiHat = () => {
+    const ctx = audioContext;
+    if (ctx && stage) {
+      // TODO
+      // shouldn't make this on every click
+      const openHihat = makeOpenHiHat(ctx);
+
+      stage.addInstrument("openHihat", openHihat);
+
+      // TODO
+      // allow trigger of n names
+      stage.trigger("openHihat");
+
+      console.log("Open HiHat triggered!");
     }
   };
 
@@ -111,7 +128,8 @@ export default function ReactTestPage() {
 
       <button onClick={triggerKick}>Kick</button>
       <button onClick={triggerSnare}>Snare</button>
-      <button onClick={triggerHiHat}>HiHat</button>
+      <button onClick={triggerClosedHiHat}>Closed HiHat</button>
+      <button onClick={triggerOpenHiHat}>Open HiHat</button>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useLibGooey } from "@/package/src/libgooey";
 import { makeKick } from "@/package/src/kick";
 import { makeSnare } from "@/package/src/snare";
+import { makeClosedHiHat } from "@/package/src/hihat";
 
 export default function ReactTestPage() {
   const { audioContext, isLoaded, isLoading, error, initialize, stage } =
@@ -51,6 +52,23 @@ export default function ReactTestPage() {
     }
   };
 
+  const triggerHiHat = () => {
+    const ctx = audioContext;
+    if (ctx && stage) {
+      // TODO
+      // shouldn't make this on every click
+      const hihat1 = makeClosedHiHat(ctx);
+
+      stage.addInstrument("hihat", hihat1);
+
+      // TODO
+      // allow trigger of n names
+      stage.trigger("hihat");
+
+      console.log("HiHat triggered!");
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="p-8">
@@ -93,6 +111,7 @@ export default function ReactTestPage() {
 
       <button onClick={triggerKick}>Kick</button>
       <button onClick={triggerSnare}>Snare</button>
+      <button onClick={triggerHiHat}>HiHat</button>
     </div>
   );
 }

--- a/package/src/hihat.ts
+++ b/package/src/hihat.ts
@@ -61,7 +61,7 @@ export const makeOpenHiHat = (ctx: AudioContext) => {
   const brightnessNoise = new Noise(ctx);
 
   // High-frequency oscillator for metallic character
-  const metallicOsc = new Oscillator(ctx, 8000.0, OscType.Sine);
+  const metallicOsc = new Oscillator(ctx, 5000.0, OscType.Sine);
 
   // Open hi-hat: longer decay, more sustain
   mainNoise.setADSR({
@@ -81,8 +81,8 @@ export const makeOpenHiHat = (ctx: AudioContext) => {
   metallicOsc.setADSR({
     attack: 0.001, // Quick attack
     decay: 0.32, // Medium decay
-    sustain: 0.2, // Low sustain
-    release: 0.48, // Longer release for open sound
+    sustain: 0.05, // Very low sustain
+    release: 0.24, // Medium release for open sound
   });
 
   // Add pitch envelope to metallic oscillator for more character

--- a/package/src/hihat.ts
+++ b/package/src/hihat.ts
@@ -2,46 +2,7 @@ import { Instrument } from "./instrument";
 import { Oscillator, OscType } from "./oscillator";
 import { Noise } from "./noise";
 
-export interface HiHatConfig {
-  base_frequency: number; // Base frequency for filtering (6000-12000Hz typical)
-  resonance: number; // Filter resonance (0.0-1.0)
-  brightness: number; // High-frequency content (0.0-1.0)
-  decay_time: number; // Decay length in seconds
-  attack_time: number; // Attack time in seconds
-  volume: number; // Overall volume (0.0-1.0)
-  is_open: boolean; // true for open, false for closed
-}
-
-const createHiHatConfig = (
-  base_frequency: number,
-  resonance: number,
-  brightness: number,
-  decay_time: number,
-  attack_time: number,
-  volume: number,
-  is_open: boolean,
-): HiHatConfig => {
-  return {
-    base_frequency: Math.max(4000.0, Math.min(16000.0, base_frequency)), // Reasonable hi-hat range
-    resonance: Math.max(0.0, Math.min(1.0, resonance)),
-    brightness: Math.max(0.0, Math.min(1.0, brightness)),
-    decay_time: Math.max(0.01, Math.min(3.0, decay_time)), // Reasonable decay range
-    attack_time: Math.max(0.001, Math.min(0.1, attack_time)), // Quick attack for hi-hats
-    volume: Math.max(0.0, Math.min(1.0, volume)),
-    is_open,
-  };
-};
-
-const closedDefault = (): HiHatConfig =>
-  createHiHatConfig(8000.0, 0.7, 0.6, 0.1, 0.001, 0.8, false);
-
-const openDefault = (): HiHatConfig =>
-  createHiHatConfig(8000.0, 0.5, 0.8, 0.8, 0.001, 0.7, true);
-
-export const makeHiHat = (
-  ctx: AudioContext,
-  config: HiHatConfig = closedDefault(),
-) => {
+export const makeClosedHiHat = (ctx: AudioContext) => {
   const inst = new Instrument(ctx);
 
   // Main noise source for the hi-hat body
@@ -51,60 +12,36 @@ export const makeHiHat = (
   const brightnessNoise = new Noise(ctx);
 
   // High-frequency oscillator for metallic character
-  const metallicOsc = new Oscillator(ctx, config.base_frequency, OscType.Sine);
+  const metallicOsc = new Oscillator(ctx, 8000.0, OscType.Sine);
 
-  if (config.is_open) {
-    // Open hi-hat: longer decay, more sustain
-    mainNoise.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.3, // Medium decay
-      sustain: 0.3, // Some sustain for open sound
-      release: config.decay_time * 0.7, // Longer release
-    });
+  // Closed hi-hat: very short decay, no sustain
+  mainNoise.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.08, // Most of the decay
+    sustain: 0.0, // No sustain for closed sound
+    release: 0.02, // Short release
+  });
 
-    brightnessNoise.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.3, // Shorter decay for brightness
-      sustain: 0.0, // No sustain
-      release: config.decay_time * 0.1, // Very short release
-    });
+  brightnessNoise.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.03, // Shorter decay for brightness
+    sustain: 0.0, // No sustain
+    release: 0.01, // Very short release
+  });
 
-    metallicOsc.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.4, // Medium decay
-      sustain: 0.2, // Low sustain
-      release: config.decay_time * 0.6, // Longer release for open sound
-    });
-  } else {
-    // Closed hi-hat: very short decay, no sustain
-    mainNoise.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.8, // Most of the decay
-      sustain: 0.0, // No sustain for closed sound
-      release: config.decay_time * 0.2, // Short release
-    });
-
-    brightnessNoise.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.3, // Shorter decay for brightness
-      sustain: 0.0, // No sustain
-      release: config.decay_time * 0.1, // Very short release
-    });
-
-    metallicOsc.setADSR({
-      attack: config.attack_time, // Quick attack
-      decay: config.decay_time * 0.9, // Most of the decay
-      sustain: 0.0, // No sustain for closed sound
-      release: config.decay_time * 0.1, // Very short release
-    });
-  }
+  metallicOsc.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.09, // Most of the decay
+    sustain: 0.0, // No sustain for closed sound
+    release: 0.01, // Very short release
+  });
 
   // Add pitch envelope to metallic oscillator for more character
   metallicOsc.setPitchADSR({
-    attack: config.attack_time, // Instant attack
-    decay: config.decay_time * 0.2, // Quick pitch drop
+    attack: 0.001, // Instant attack
+    decay: 0.02, // Quick pitch drop
     sustain: 0.0, // Drop to base frequency
-    release: config.decay_time * 0.1, // Quick release
+    release: 0.01, // Quick release
   });
 
   inst.addGenerator("main", mainNoise);
@@ -114,9 +51,51 @@ export const makeHiHat = (
   return inst;
 };
 
-// Convenience functions for different hi-hat types
-export const makeClosedHiHat = (ctx: AudioContext) =>
-  makeHiHat(ctx, closedDefault());
+export const makeOpenHiHat = (ctx: AudioContext) => {
+  const inst = new Instrument(ctx);
 
-export const makeOpenHiHat = (ctx: AudioContext) =>
-  makeHiHat(ctx, openDefault());
+  // Main noise source for the hi-hat body
+  const mainNoise = new Noise(ctx);
+
+  // Brightness noise for high-frequency emphasis
+  const brightnessNoise = new Noise(ctx);
+
+  // High-frequency oscillator for metallic character
+  const metallicOsc = new Oscillator(ctx, 8000.0, OscType.Sine);
+
+  // Open hi-hat: longer decay, more sustain
+  mainNoise.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.24, // Medium decay
+    sustain: 0.3, // Some sustain for open sound
+    release: 0.56, // Longer release
+  });
+
+  brightnessNoise.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.24, // Shorter decay for brightness
+    sustain: 0.0, // No sustain
+    release: 0.08, // Very short release
+  });
+
+  metallicOsc.setADSR({
+    attack: 0.001, // Quick attack
+    decay: 0.32, // Medium decay
+    sustain: 0.2, // Low sustain
+    release: 0.48, // Longer release for open sound
+  });
+
+  // Add pitch envelope to metallic oscillator for more character
+  metallicOsc.setPitchADSR({
+    attack: 0.001, // Instant attack
+    decay: 0.16, // Quick pitch drop
+    sustain: 0.0, // Drop to base frequency
+    release: 0.08, // Quick release
+  });
+
+  inst.addGenerator("main", mainNoise);
+  inst.addGenerator("brightness", brightnessNoise);
+  inst.addGenerator("metallic", metallicOsc);
+
+  return inst;
+};

--- a/package/src/hihat.ts
+++ b/package/src/hihat.ts
@@ -1,0 +1,122 @@
+import { Instrument } from "./instrument";
+import { Oscillator, OscType } from "./oscillator";
+import { Noise } from "./noise";
+
+export interface HiHatConfig {
+  base_frequency: number; // Base frequency for filtering (6000-12000Hz typical)
+  resonance: number; // Filter resonance (0.0-1.0)
+  brightness: number; // High-frequency content (0.0-1.0)
+  decay_time: number; // Decay length in seconds
+  attack_time: number; // Attack time in seconds
+  volume: number; // Overall volume (0.0-1.0)
+  is_open: boolean; // true for open, false for closed
+}
+
+const createHiHatConfig = (
+  base_frequency: number,
+  resonance: number,
+  brightness: number,
+  decay_time: number,
+  attack_time: number,
+  volume: number,
+  is_open: boolean,
+): HiHatConfig => {
+  return {
+    base_frequency: Math.max(4000.0, Math.min(16000.0, base_frequency)), // Reasonable hi-hat range
+    resonance: Math.max(0.0, Math.min(1.0, resonance)),
+    brightness: Math.max(0.0, Math.min(1.0, brightness)),
+    decay_time: Math.max(0.01, Math.min(3.0, decay_time)), // Reasonable decay range
+    attack_time: Math.max(0.001, Math.min(0.1, attack_time)), // Quick attack for hi-hats
+    volume: Math.max(0.0, Math.min(1.0, volume)),
+    is_open,
+  };
+};
+
+const closedDefault = (): HiHatConfig =>
+  createHiHatConfig(8000.0, 0.7, 0.6, 0.1, 0.001, 0.8, false);
+
+const openDefault = (): HiHatConfig =>
+  createHiHatConfig(8000.0, 0.5, 0.8, 0.8, 0.001, 0.7, true);
+
+export const makeHiHat = (
+  ctx: AudioContext,
+  config: HiHatConfig = closedDefault(),
+) => {
+  const inst = new Instrument(ctx);
+
+  // Main noise source for the hi-hat body
+  const mainNoise = new Noise(ctx);
+
+  // Brightness noise for high-frequency emphasis
+  const brightnessNoise = new Noise(ctx);
+
+  // High-frequency oscillator for metallic character
+  const metallicOsc = new Oscillator(ctx, config.base_frequency, OscType.Sine);
+
+  if (config.is_open) {
+    // Open hi-hat: longer decay, more sustain
+    mainNoise.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.3, // Medium decay
+      sustain: 0.3, // Some sustain for open sound
+      release: config.decay_time * 0.7, // Longer release
+    });
+
+    brightnessNoise.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.3, // Shorter decay for brightness
+      sustain: 0.0, // No sustain
+      release: config.decay_time * 0.1, // Very short release
+    });
+
+    metallicOsc.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.4, // Medium decay
+      sustain: 0.2, // Low sustain
+      release: config.decay_time * 0.6, // Longer release for open sound
+    });
+  } else {
+    // Closed hi-hat: very short decay, no sustain
+    mainNoise.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.8, // Most of the decay
+      sustain: 0.0, // No sustain for closed sound
+      release: config.decay_time * 0.2, // Short release
+    });
+
+    brightnessNoise.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.3, // Shorter decay for brightness
+      sustain: 0.0, // No sustain
+      release: config.decay_time * 0.1, // Very short release
+    });
+
+    metallicOsc.setADSR({
+      attack: config.attack_time, // Quick attack
+      decay: config.decay_time * 0.9, // Most of the decay
+      sustain: 0.0, // No sustain for closed sound
+      release: config.decay_time * 0.1, // Very short release
+    });
+  }
+
+  // Add pitch envelope to metallic oscillator for more character
+  metallicOsc.setPitchADSR({
+    attack: config.attack_time, // Instant attack
+    decay: config.decay_time * 0.2, // Quick pitch drop
+    sustain: 0.0, // Drop to base frequency
+    release: config.decay_time * 0.1, // Quick release
+  });
+
+  inst.addGenerator("main", mainNoise);
+  inst.addGenerator("brightness", brightnessNoise);
+  inst.addGenerator("metallic", metallicOsc);
+
+  return inst;
+};
+
+// Convenience functions for different hi-hat types
+export const makeClosedHiHat = (ctx: AudioContext) =>
+  makeHiHat(ctx, closedDefault());
+
+export const makeOpenHiHat = (ctx: AudioContext) =>
+  makeHiHat(ctx, openDefault());


### PR DESCRIPTION
Implements a new hihat instrument following existing code conventions as requested in issue #7.

## Changes
- Added `makeHiHat` factory function in `package/src/hihat.ts`
- Supports both open and closed hihat configurations
- Uses Noise generators and metallic Oscillator for authentic sound
- Added hihat button to debug UI in `app/page.tsx`
- Follows existing patterns from kick and snare instruments

Closes #7

Generated with [Claude Code](https://claude.ai/code)