### PR TITLE
Add per-instrument and master gain control to Stage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,13 @@ export default function ReactTestPage() {
     hat: [1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1],
   });
 
+  const [volumes, setVolumes] = useState({
+    master: 1,
+    kick: 1,
+    snare: 1,
+    hat: 1,
+  });
+
   const { audioContext, isLoaded, isLoading, error, initialize, stage } =
     useLibGooey({
       autoInit: false, // Manual initialization for demo
@@ -61,6 +68,18 @@ export default function ReactTestPage() {
 
       return newPatterns;
     });
+  };
+
+  const handleVolumeChange = (target: string, value: number) => {
+    setVolumes((prev) => ({ ...prev, [target]: value }));
+    
+    if (stage) {
+      if (target === 'master') {
+        stage.setMainVolume(value);
+      } else {
+        stage.setInstrumentVolume(target, value);
+      }
+    }
   };
 
   const triggerKick = () => {
@@ -247,6 +266,51 @@ export default function ReactTestPage() {
                     </svg>
                   );
                 })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="my-6">
+        <h3 className="text-lg font-semibold mb-3">Volume Controls</h3>
+        <div className="space-y-3">
+          {/* Master Volume */}
+          <div className="flex items-center gap-4">
+            <div className="w-16 text-sm font-medium text-gray-700">
+              Master
+            </div>
+            <input
+              type="range"
+              min="0"
+              max="2"
+              step="0.01"
+              value={volumes.master}
+              onChange={(e) => handleVolumeChange('master', parseFloat(e.target.value))}
+              className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+            />
+            <div className="w-12 text-sm text-gray-600">
+              {(volumes.master * 100).toFixed(0)}%
+            </div>
+          </div>
+
+          {/* Instrument Volumes */}
+          {instruments.map((instrument) => (
+            <div key={instrument} className="flex items-center gap-4">
+              <div className="w-16 text-sm font-medium text-gray-700 capitalize">
+                {instrument}
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="2"
+                step="0.01"
+                value={volumes[instrument as keyof typeof volumes]}
+                onChange={(e) => handleVolumeChange(instrument, parseFloat(e.target.value))}
+                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+              />
+              <div className="w-12 text-sm text-gray-600">
+                {(volumes[instrument as keyof typeof volumes] * 100).toFixed(0)}%
               </div>
             </div>
           ))}

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -36,25 +36,25 @@ export class Instrument {
   //   }
   // }
 
-    // trigger sort of only makes sense for "oneshot instruments"
-    trigger() {
-      this.triggerAt(this.ctx.currentTime);
-    }
-  
-    triggerAt(time: number) {
-      for (const key in this.generators) {
-        if (this.generators.hasOwnProperty(key)) {
-          const gen = this.generators[key].gen;
-          const osc = gen.start(time);
-  
-          if (osc) {
-            // the stop time should really be controlled by
-            // the generator's own envelope choice
-            osc.stop(this.ctx.currentTime + 0.5);
-          }
+  // trigger sort of only makes sense for "oneshot instruments"
+  trigger(destination?: AudioNode) {
+    this.triggerAt(this.ctx.currentTime, destination);
+  }
+
+  triggerAt(time: number, destination?: AudioNode) {
+    for (const key in this.generators) {
+      if (this.generators.hasOwnProperty(key)) {
+        const gen = this.generators[key].gen;
+        const osc = gen.start(time, destination);
+
+        if (osc) {
+          // the stop time should really be controlled by
+          // the generator's own envelope choice
+          osc.stop(this.ctx.currentTime + 0.5);
         }
       }
     }
+  }
 }
 
 // export class OneShot extends Instrument {

--- a/package/src/libgooey.ts
+++ b/package/src/libgooey.ts
@@ -32,7 +32,7 @@ export interface UseLibGooeyReturn {
 }
 
 export function useLibGooey(
-  options: UseLibGooeyOptions = {}
+  options: UseLibGooeyOptions = {},
 ): UseLibGooeyReturn {
   const { sampleRate = 44100, autoInit = true } = options;
 
@@ -58,6 +58,9 @@ export function useLibGooey(
 
     audioContextRef.current = ctx;
     stageRef.current = new Stage(ctx);
+
+    // Connect the stage to the audio destination
+    stageRef.current.connect();
 
     console.log("context", ctx);
 

--- a/package/src/libgooey.ts
+++ b/package/src/libgooey.ts
@@ -59,9 +59,6 @@ export function useLibGooey(
     audioContextRef.current = ctx;
     stageRef.current = new Stage(ctx);
 
-    // Connect the stage to the audio destination
-    stageRef.current.connect();
-
     console.log("context", ctx);
 
     try {

--- a/package/src/noise.ts
+++ b/package/src/noise.ts
@@ -10,7 +10,7 @@ export class Noise {
     this.ctx = ctx;
   }
 
-  makeBufferSource() {
+  makeBufferSource(destination?: AudioNode) {
     const bufferSize = this.ctx.sampleRate * 0.2; // 0.2 seconds
     const buffer = this.ctx.createBuffer(1, bufferSize, this.ctx.sampleRate);
     const data = buffer.getChannelData(0);
@@ -27,9 +27,9 @@ export class Noise {
 
     bufferSource.connect(gain);
 
-    // TODO
-    // connect to master gain
-    gain.connect(this.ctx.destination);
+    // Connect to the provided destination or default to audio context destination
+    const target = destination || this.ctx.destination;
+    gain.connect(target);
 
     return { bufferSource, gain };
   }
@@ -42,8 +42,8 @@ export class Noise {
     this.envelope = new Envelope(this.ctx, config);
   }
 
-  start(time: number) {
-    const { bufferSource, gain } = this.makeBufferSource();
+  start(time: number, destination?: AudioNode) {
+    const { bufferSource, gain } = this.makeBufferSource(destination);
     bufferSource.start(time);
 
     // Apply envelope if one is set

--- a/package/src/oscillator.ts
+++ b/package/src/oscillator.ts
@@ -21,7 +21,7 @@ export class Oscillator {
     // this.gain =
   }
 
-  makeOscillator() {
+  makeOscillator(destination?: AudioNode) {
     const now = this.ctx.currentTime;
     const gain = this.ctx.createGain();
     const osc = this.ctx.createOscillator();
@@ -41,10 +41,9 @@ export class Oscillator {
 
     osc.connect(gain);
 
-    // TODO
-    // this needs to be lifted if we want stage to
-    // have a top level "two bus" style gain
-    gain.connect(this.ctx.destination);
+    // Connect to the provided destination or default to audio context destination
+    const target = destination || this.ctx.destination;
+    gain.connect(target);
 
     return { osc, gain };
   }
@@ -63,8 +62,8 @@ export class Oscillator {
 
   // creating the oscillator node on start, instead of constructor
   // allows us to trigger many instances during sequencer lookahead
-  start(time: number) {
-    const { osc, gain } = this.makeOscillator();
+  start(time: number, destination?: AudioNode) {
+    const { osc, gain } = this.makeOscillator(destination);
     osc.start(time);
 
     // Apply envelope if one is set

--- a/package/src/stage.ts
+++ b/package/src/stage.ts
@@ -17,24 +17,22 @@ export class Stage {
     this.ctx = audioContext;
     this.instruments = {};
     this.mainOut = this.ctx.createGain();
+    this.mainOut.gain.setValueAtTime(1, this.ctx.currentTime);
   }
 
   addInstrument(name: string, instrument: Instrument) {
-    // TODO
-    // enforce name is not already taken
+    // TODO: enforce name is not already taken
+    if (this.instruments[name]) {
+      console.warn(
+        `Instrument "${name}" already exists. Replacing existing instrument.`,
+      );
+    }
 
     const gain = this.ctx.createGain();
+    gain.gain.setValueAtTime(1, this.ctx.currentTime);
 
-    //
-    // gain.gain.setValueAtTime(1, this.ctx.currentTime);
-
-    // link gain to ctx
-    // gain.connect(this.ctx.destination);
-
-    // link incomming instrument
-    // to its _own_ gain channel
-    // so stage can do mix down
-    // instrument.connect(gain);
+    // Connect instrument's gain to the main output
+    gain.connect(this.mainOut);
 
     this.instruments[name] = {
       instrument,
@@ -46,18 +44,46 @@ export class Stage {
   // check that name exists
   trigger(name: string) {
     const instChannel = this.instruments[name];
-    instChannel.instrument.trigger();
+    if (instChannel) {
+      instChannel.instrument.trigger(instChannel.gain);
+    }
   }
 
   triggerAt(name: string, time: number) {
     const instChannel = this.instruments[name];
-    instChannel.instrument.triggerAt(time);
+    if (instChannel) {
+      instChannel.instrument.triggerAt(time, instChannel.gain);
+    }
   }
 
-  // TODO
-  // need to pass stage level gain into the instrument itself
-  // to use for sub-staging, unless sub-gain works
-  setVolume(name: string, amt: number) {
-    this.instruments[name].gain.gain.setValueAtTime(amt, this.ctx.currentTime);
+  // Set the main/master volume for the entire stage
+  setMainVolume(amt: number) {
+    this.mainOut.gain.setValueAtTime(amt, this.ctx.currentTime);
+  }
+
+  // Set the volume for a specific instrument
+  setInstrumentVolume(name: string, amt: number) {
+    if (this.instruments[name]) {
+      this.instruments[name].gain.gain.setValueAtTime(
+        amt,
+        this.ctx.currentTime,
+      );
+    }
+  }
+
+  // Connect the stage's main output to the audio context destination
+  connect(destination?: AudioNode) {
+    const target = destination || this.ctx.destination;
+    this.mainOut.connect(target);
+  }
+
+  // Disconnect the stage from its current destination
+  disconnect() {
+    this.mainOut.disconnect();
+  }
+
+  // Get the main output node for advanced routing
+  getMainOutput(): GainNode {
+    return this.mainOut;
   }
 }

--- a/package/src/stage.ts
+++ b/package/src/stage.ts
@@ -13,11 +13,15 @@ export class Stage {
   private mainOut: GainNode;
   private instruments: Record<string, InstrumentChannel>;
 
-  constructor(audioContext: AudioContext) {
+  constructor(audioContext: AudioContext, destination?: AudioNode) {
     this.ctx = audioContext;
     this.instruments = {};
     this.mainOut = this.ctx.createGain();
     this.mainOut.gain.setValueAtTime(1, this.ctx.currentTime);
+
+    // Auto-connect to destination (default: audio context destination)
+    const target = destination || this.ctx.destination;
+    this.mainOut.connect(target);
   }
 
   addInstrument(name: string, instrument: Instrument) {


### PR DESCRIPTION
This PR implements the requested capability to modify gain for individual instruments as well as the master gain of the "stage" abstraction.

## Changes

- Add `setMainVolume()` method to control master gain
- Rename `setVolume()` to `setInstrumentVolume()` for clarity
- Implement proper audio routing through gain nodes
- Update audio generators to accept destination parameter
- Add stage connection methods for advanced routing
- Ensure stage connects to audio destination in useLibGooey hook

The implementation uses existing Web Audio API gain nodes where possible and provides all modification APIs through the Stage abstraction as requested.

Closes #11

Generated with [Claude Code](https://claude.ai/code)