### PR TITLE
Add pink noise generator and reorganize noise generators

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from "react";
 import { useLibGooey } from "@/package/src/libgooey";
 import { makeKick } from "@/package/src/kick";
 import { makeSnare } from "@/package/src/snare";
+import { makePinkHat } from "@/package/src/pink-hat";
 import { Sequencer } from "@/package/src/sequencer";
 import { useBeatTracker } from "@/package/src/hooks";
 
@@ -12,6 +13,7 @@ export default function ReactTestPage() {
     kick: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
     snare: [0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
     hat: [1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1],
+    pinkHat: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
   });
 
   const [volumes, setVolumes] = useState({
@@ -19,6 +21,7 @@ export default function ReactTestPage() {
     kick: 1,
     snare: 1,
     hat: 1,
+    pinkHat: 1,
   });
 
   const { audioContext, isLoaded, isLoading, error, initialize, stage } =
@@ -118,6 +121,23 @@ export default function ReactTestPage() {
     }
   };
 
+  const triggerPinkHat = () => {
+    const ctx = audioContext;
+    if (ctx && stage) {
+      // TODO
+      // shouldn't make this on every click
+      const pinkHat1 = makePinkHat(ctx, { decay_time: 0.12 });
+
+      stage.addInstrument("pinkHat", pinkHat1);
+
+      // TODO
+      // allow trigger of n names
+      stage.trigger("pinkHat");
+
+      console.log("Pink Hat triggered!");
+    }
+  };
+
   const startSequencer = () => {
     const ctx = audioContext;
 
@@ -132,6 +152,9 @@ export default function ReactTestPage() {
 
       const hat = makeSnare(ctx, 200, 800);
       stage.addInstrument("hat", hat);
+
+      const pinkHat = makePinkHat(ctx, { decay_time: 0.1 });
+      stage.addInstrument("pinkHat", pinkHat);
 
       const sequencer = new Sequencer(ctx, {
         tempo: 120,
@@ -214,6 +237,12 @@ export default function ReactTestPage() {
           className="px-6 py-3 bg-black/20 border border-white/10 rounded-xl text-white font-medium hover:bg-black/40 hover:border-white/20 transition-all duration-200 backdrop-blur-sm"
         >
           Snare
+        </button>
+        <button 
+          onClick={triggerPinkHat}
+          className="px-6 py-3 bg-pink-500/20 border border-pink-300/20 rounded-xl text-white font-medium hover:bg-pink-500/40 hover:border-pink-300/40 transition-all duration-200 backdrop-blur-sm"
+        >
+          Pink Hat
         </button>
         <button 
           onClick={startSequencer}

--- a/package/src/generators/index.ts
+++ b/package/src/generators/index.ts
@@ -1,0 +1,5 @@
+export { WhiteNoise } from "./white-noise";
+export { PinkNoise } from "./pink-noise";
+
+// Backward compatibility: export WhiteNoise as Noise
+export { WhiteNoise as Noise } from "./white-noise";

--- a/package/src/generators/pink-noise.ts
+++ b/package/src/generators/pink-noise.ts
@@ -1,0 +1,69 @@
+import { Envelope, ADSRConfig } from "../envelope";
+
+export class PinkNoise {
+  private ctx: AudioContext;
+  private envelope?: Envelope;
+
+  constructor(ctx: AudioContext) {
+    this.ctx = ctx;
+  }
+
+  makeBufferSource(destination?: AudioNode) {
+    const bufferSize = this.ctx.sampleRate * 0.2; // 0.2 seconds
+    const buffer = this.ctx.createBuffer(1, bufferSize, this.ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+
+    // Pink noise using Paul Kellet's method
+    let b0 = 0,
+      b1 = 0,
+      b2 = 0,
+      b3 = 0,
+      b4 = 0,
+      b5 = 0,
+      b6 = 0;
+
+    for (let i = 0; i < bufferSize; i++) {
+      const white = Math.random() * 2 - 1;
+
+      b0 = 0.99886 * b0 + white * 0.0555179;
+      b1 = 0.99332 * b1 + white * 0.0750759;
+      b2 = 0.969 * b2 + white * 0.153852;
+      b3 = 0.8665 * b3 + white * 0.3104856;
+      b4 = 0.55 * b4 + white * 0.5329522;
+      b5 = -0.7616 * b5 - white * 0.016898;
+
+      data[i] = (b0 + b1 + b2 + b3 + b4 + b5 + b6 + white * 0.5362) * 0.11;
+      b6 = white * 0.115926;
+    }
+
+    const bufferSource = this.ctx.createBufferSource();
+    bufferSource.buffer = buffer;
+
+    const gain = this.ctx.createGain();
+    gain.gain.setValueAtTime(1, this.ctx.currentTime);
+
+    bufferSource.connect(gain);
+
+    // Connect to the provided destination or default to audio context destination
+    const target = destination || this.ctx.destination;
+    gain.connect(target);
+
+    return { bufferSource, gain };
+  }
+
+  setADSR(config: ADSRConfig) {
+    this.envelope = new Envelope(this.ctx, config);
+  }
+
+  start(time: number, destination?: AudioNode) {
+    const { bufferSource, gain } = this.makeBufferSource(destination);
+    bufferSource.start(time);
+
+    // Apply envelope if one is set
+    if (this.envelope) {
+      this.envelope.apply(gain, time);
+    }
+
+    return bufferSource;
+  }
+}

--- a/package/src/generators/white-noise.ts
+++ b/package/src/generators/white-noise.ts
@@ -1,9 +1,7 @@
-import { Envelope, ADSRConfig } from "./envelope";
+import { Envelope, ADSRConfig } from "../envelope";
 
-export class Noise {
+export class WhiteNoise {
   private ctx: AudioContext;
-  // private gain: GainNode;
-  // private bufferSource: AudioBufferSourceNode;
   private envelope?: Envelope;
 
   constructor(ctx: AudioContext) {
@@ -34,10 +32,6 @@ export class Noise {
     return { bufferSource, gain };
   }
 
-  // connect(gain: GainNode) {
-  //   this.gain.connect(gain);
-  // }
-
   setADSR(config: ADSRConfig) {
     this.envelope = new Envelope(this.ctx, config);
   }
@@ -53,8 +47,4 @@ export class Noise {
 
     return bufferSource;
   }
-
-  // stop(future: number) {
-  //   this.bufferSource.stop(future);
-  // }
 }

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -1,8 +1,8 @@
 import { Oscillator } from "./oscillator";
-import { Noise } from "./noise";
+import { Noise, WhiteNoise, PinkNoise } from "./generators";
 
 // Define a type for any generator (Oscillator or Noise)
-export type AudioGenerator = Oscillator | Noise;
+export type AudioGenerator = Oscillator | Noise | WhiteNoise | PinkNoise;
 
 type InstGenerator = {
   gen: AudioGenerator;

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -1,6 +1,6 @@
 import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
-import { Noise } from "./noise";
+import { Noise } from "./generators";
 
 export const makeKick = (ctx: AudioContext, freq1: number, freq2: number) => {
   const inst = new Instrument(ctx);

--- a/package/src/pink-hat.ts
+++ b/package/src/pink-hat.ts
@@ -1,0 +1,27 @@
+import { Instrument } from "./instrument";
+import { PinkNoise } from "./generators";
+
+export interface PinkHatConfig {
+  decay_time: number;
+}
+
+export const makePinkHat = (
+  ctx: AudioContext,
+  config: PinkHatConfig = { decay_time: 0.15 },
+) => {
+  const inst = new Instrument(ctx);
+
+  const pinkNoise = new PinkNoise(ctx);
+
+  // Apply ADSR settings to the pink noise - shorter than snare for hat-like sound
+  pinkNoise.setADSR({
+    attack: 0.001, // Very fast attack
+    decay: config.decay_time * 0.8, // Quick decay for crisp hat sound
+    sustain: 0.0, // No sustain - hats should decay to silence quickly
+    release: config.decay_time * 0.3, // Quick release
+  });
+
+  inst.addGenerator("pink", pinkNoise);
+
+  return inst;
+};

--- a/package/src/snare.ts
+++ b/package/src/snare.ts
@@ -1,6 +1,6 @@
 import { Instrument } from "./instrument";
 import { Oscillator, OscType } from "./oscillator";
-import { Noise } from "./noise";
+import { Noise } from "./generators";
 import { Envelope } from "./envelope";
 
 export interface SnareConfig {
@@ -11,7 +11,7 @@ export const makeSnare = (
   ctx: AudioContext,
   freq1: number,
   freq2: number,
-  config: SnareConfig = { decay_time: 0.3 }
+  config: SnareConfig = { decay_time: 0.3 },
 ) => {
   const inst = new Instrument(ctx);
 


### PR DESCRIPTION
Resolves #16

Adds an optional pink noise generator and reorganizes noise generators into their own directory following existing conventions.

## Changes
- Create `generators/` directory with WhiteNoise and PinkNoise classes
- Move existing noise implementation to WhiteNoise class
- Implement PinkNoise using Paul Kellet's algorithm for 1/f frequency response
- Maintain backward compatibility by exporting WhiteNoise as Noise
- Update imports in kick.ts, snare.ts, and instrument.ts
- Remove old noise.ts file

## Usage
```typescript
import { WhiteNoise, PinkNoise } from "./generators"