### PR TITLE
Implement low-pass filter with optional ADSR modulation

### DIFF
--- a/package/src/envelope.ts
+++ b/package/src/envelope.ts
@@ -1,8 +1,8 @@
 export interface ADSRConfig {
-  attack: number;    // Attack time in seconds
-  decay: number;     // Decay time in seconds
-  sustain: number;   // Sustain level (0-1)
-  release: number;   // Release time in seconds
+  attack: number; // Attack time in seconds
+  decay: number; // Decay time in seconds
+  sustain: number; // Sustain level (0-1)
+  release: number; // Release time in seconds
 }
 
 export class Envelope {
@@ -15,7 +15,11 @@ export class Envelope {
   }
 
   // Apply the ADSR envelope to a GainNode
-  apply(gainNode: GainNode, startTime: number = this.ctx.currentTime, noteLength?: number) {
+  apply(
+    gainNode: GainNode,
+    startTime: number = this.ctx.currentTime,
+    noteLength?: number,
+  ) {
     const { attack, decay, sustain, release } = this.config;
     const gain = gainNode.gain;
 
@@ -28,16 +32,17 @@ export class Envelope {
     // Decay phase: ramp down to sustain level
     gain.exponentialRampToValueAtTime(
       Math.max(sustain, 0.001), // Ensure sustain is not exactly 0 for exponential ramp
-      startTime + attack + decay
+      startTime + attack + decay,
     );
 
     // If sustain is 0 (like drums), start release immediately after decay
     // Otherwise, sustain until note release
     if (sustain === 0 || noteLength !== undefined) {
-      const releaseStart = noteLength !== undefined 
-        ? startTime + noteLength
-        : startTime + attack + decay;
-      
+      const releaseStart =
+        noteLength !== undefined
+          ? startTime + noteLength
+          : startTime + attack + decay;
+
       // Release phase: ramp down to silence
       gain.exponentialRampToValueAtTime(0.001, releaseStart + release);
     }
@@ -46,14 +51,20 @@ export class Envelope {
   }
 
   // Apply the ADSR envelope to an oscillator's frequency
-  applyToPitch(oscillator: OscillatorNode, baseFrequency: number, pitchRange: number = 1.0, startTime: number = this.ctx.currentTime, noteLength?: number) {
+  applyToPitch(
+    oscillator: OscillatorNode,
+    baseFrequency: number,
+    pitchRange: number = 1.0,
+    startTime: number = this.ctx.currentTime,
+    noteLength?: number,
+  ) {
     const { attack, decay, sustain, release } = this.config;
     const frequency = oscillator.frequency;
 
     // Start at base frequency + pitch range (high pitch)
-    const startFreq = baseFrequency + (baseFrequency * pitchRange);
-    const sustainFreq = baseFrequency + (baseFrequency * pitchRange * sustain);
-    
+    const startFreq = baseFrequency + baseFrequency * pitchRange;
+    const sustainFreq = baseFrequency + baseFrequency * pitchRange * sustain;
+
     frequency.setValueAtTime(startFreq, startTime);
 
     // Attack phase: stay at high pitch
@@ -62,20 +73,65 @@ export class Envelope {
     // Decay phase: drop to sustain frequency
     frequency.exponentialRampToValueAtTime(
       Math.max(sustainFreq, baseFrequency * 0.1), // Ensure frequency doesn't go too low
-      startTime + attack + decay
+      startTime + attack + decay,
     );
 
     // If sustain is 0 (like drums), start release immediately after decay
     // Otherwise, sustain until note release
     if (sustain === 0 || noteLength !== undefined) {
-      const releaseStart = noteLength !== undefined 
-        ? startTime + noteLength
-        : startTime + attack + decay;
-      
+      const releaseStart =
+        noteLength !== undefined
+          ? startTime + noteLength
+          : startTime + attack + decay;
+
       // Release phase: return to base frequency
-      frequency.exponentialRampToValueAtTime(baseFrequency, releaseStart + release);
+      frequency.exponentialRampToValueAtTime(
+        baseFrequency,
+        releaseStart + release,
+      );
     }
   }
 
-}
+  // Apply the ADSR envelope to a filter's frequency parameter
+  applyToFilter(
+    filter: BiquadFilterNode,
+    baseFrequency: number,
+    frequencyRange: number = 1.0,
+    startTime: number = this.ctx.currentTime,
+    noteLength?: number,
+  ) {
+    const { attack, decay, sustain, release } = this.config;
+    const frequency = filter.frequency;
 
+    // Start at base frequency + range (high frequency for low-pass)
+    const startFreq = baseFrequency + baseFrequency * frequencyRange;
+    const sustainFreq =
+      baseFrequency + baseFrequency * frequencyRange * sustain;
+
+    frequency.setValueAtTime(startFreq, startTime);
+
+    // Attack phase: stay at high frequency
+    frequency.linearRampToValueAtTime(startFreq, startTime + attack);
+
+    // Decay phase: drop to sustain frequency
+    frequency.exponentialRampToValueAtTime(
+      Math.max(sustainFreq, baseFrequency * 0.1), // Ensure frequency doesn't go too low
+      startTime + attack + decay,
+    );
+
+    // If sustain is 0 (like drums), start release immediately after decay
+    // Otherwise, sustain until note release
+    if (sustain === 0 || noteLength !== undefined) {
+      const releaseStart =
+        noteLength !== undefined
+          ? startTime + noteLength
+          : startTime + attack + decay;
+
+      // Release phase: return to base frequency
+      frequency.exponentialRampToValueAtTime(
+        Math.max(baseFrequency, 20),
+        releaseStart + release,
+      );
+    }
+  }
+}

--- a/package/src/filter.ts
+++ b/package/src/filter.ts
@@ -1,0 +1,66 @@
+import { Envelope, ADSRConfig } from "./envelope";
+
+export interface FilterConfig {
+  frequency: number; // Cutoff frequency in Hz
+  Q?: number; // Resonance (optional, default 1)
+  type?: BiquadFilterType; // Filter type (default 'lowpass')
+}
+
+export class Filter {
+  private ctx: AudioContext;
+  private config: FilterConfig;
+  private envelope?: Envelope;
+  private frequencyRange: number = 1.0; // Frequency modulation range (default 100%)
+
+  constructor(ctx: AudioContext, config: FilterConfig) {
+    this.ctx = ctx;
+    this.config = {
+      Q: 1,
+      type: "lowpass",
+      ...config,
+    };
+  }
+
+  // Create a fresh filter node for each trigger (following existing pattern)
+  createFilterNode(): BiquadFilterNode {
+    const filter = this.ctx.createBiquadFilter();
+    filter.type = this.config.type!;
+    filter.frequency.setValueAtTime(
+      this.config.frequency,
+      this.ctx.currentTime,
+    );
+    filter.Q.setValueAtTime(this.config.Q!, this.ctx.currentTime);
+    return filter;
+  }
+
+  // Set ADSR envelope for frequency modulation
+  setFrequencyADSR(config: ADSRConfig, frequencyRange: number = 1.0) {
+    this.envelope = new Envelope(this.ctx, config);
+    this.frequencyRange = frequencyRange;
+  }
+
+  // Apply filter to the signal chain
+  apply(
+    inputNode: AudioNode,
+    outputNode: AudioNode,
+    startTime: number,
+  ): BiquadFilterNode {
+    const filter = this.createFilterNode();
+
+    // Insert filter into signal chain
+    inputNode.connect(filter);
+    filter.connect(outputNode);
+
+    // Apply envelope to filter frequency if configured
+    if (this.envelope) {
+      this.envelope.applyToFilter(
+        filter,
+        this.config.frequency,
+        this.frequencyRange,
+        startTime,
+      );
+    }
+
+    return filter;
+  }
+}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,0 +1,27 @@
+// Core audio classes
+export { Oscillator, OscType } from "./oscillator";
+export { Noise } from "./noise";
+export { Envelope, type ADSRConfig } from "./envelope";
+export { Filter, type FilterConfig } from "./filter";
+
+// Instrument and composition
+export { Instrument } from "./instrument";
+export { makeKick, type KickConfig } from "./kick";
+export { makeSnare, type SnareConfig } from "./snare";
+
+// Audio context and stage management
+export { getAudioContext } from "./audio-context";
+export { Stage } from "./stage";
+
+// Sequencing
+export { Sequencer } from "./sequencer";
+
+// React hooks
+export {
+  useLibGooey,
+  type UseLibGooeyOptions,
+  type UseLibGooeyReturn,
+} from "./libgooey";
+
+// Utility hooks
+export { useBeatTracker } from "./hooks/useBeatTracker";

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -1,8 +1,19 @@
 import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
 import { Noise } from "./noise";
+import { FilterConfig } from "./filter";
 
-export const makeKick = (ctx: AudioContext, freq1: number, freq2: number) => {
+export interface KickConfig {
+  filter?: FilterConfig;
+  clickFilter?: FilterConfig;
+}
+
+export const makeKick = (
+  ctx: AudioContext,
+  freq1: number,
+  freq2: number,
+  config?: KickConfig,
+) => {
   const inst = new Instrument(ctx);
 
   const osc1 = new Oscillator(ctx, freq1);
@@ -23,6 +34,12 @@ export const makeKick = (ctx: AudioContext, freq1: number, freq2: number) => {
     release: 0.05, // Quick release
   });
 
+  // Add optional filters to oscillators
+  if (config?.filter) {
+    osc1.setFilter(config.filter);
+    osc2.setFilter(config.filter);
+  }
+
   // Add short "click" sound using noise generator
   const clickNoise = new Noise(ctx);
   clickNoise.setADSR({
@@ -31,6 +48,11 @@ export const makeKick = (ctx: AudioContext, freq1: number, freq2: number) => {
     sustain: 0, // No sustain
     release: 0.005, // Very quick release
   });
+
+  // Add optional filter to click noise (separate config)
+  if (config?.clickFilter) {
+    clickNoise.setFilter(config.clickFilter);
+  }
 
   inst.addGenerator("sub", osc1);
   inst.addGenerator("main", osc2);

--- a/package/src/oscillator.ts
+++ b/package/src/oscillator.ts
@@ -1,4 +1,5 @@
 import { Envelope, ADSRConfig } from "./envelope";
+import { Filter, FilterConfig } from "./filter";
 
 export enum OscType {
   Triangle,
@@ -12,6 +13,7 @@ export class Oscillator {
   // private osc: OscillatorNode;
   private envelope?: Envelope;
   private pitchEnvelope?: Envelope;
+  private filter?: Filter;
   private baseFrequency: number;
 
   constructor(ctx: AudioContext, freq: number, type: OscType = OscType.Sine) {
@@ -21,8 +23,8 @@ export class Oscillator {
     // this.gain =
   }
 
-  makeOscillator(destination?: AudioNode) {
-    const now = this.ctx.currentTime;
+  makeOscillator(destination?: AudioNode, startTime?: number) {
+    const now = startTime || this.ctx.currentTime;
     const gain = this.ctx.createGain();
     const osc = this.ctx.createOscillator();
 
@@ -39,11 +41,18 @@ export class Oscillator {
     osc.frequency.setValueAtTime(this.baseFrequency, now);
     gain.gain.setValueAtTime(0, now); // Start from silence, envelope will control volume
 
-    osc.connect(gain);
-
-    // Connect to the provided destination or default to audio context destination
+    // Set up signal chain: osc -> [filter] -> gain -> destination
     const target = destination || this.ctx.destination;
-    gain.connect(target);
+
+    if (this.filter) {
+      // Signal chain: osc -> filter -> gain -> destination
+      this.filter.apply(osc, gain, now);
+      gain.connect(target);
+    } else {
+      // Standard chain: osc -> gain -> destination
+      osc.connect(gain);
+      gain.connect(target);
+    }
 
     return { osc, gain };
   }
@@ -60,10 +69,20 @@ export class Oscillator {
     this.pitchEnvelope = new Envelope(this.ctx, config);
   }
 
+  setFilter(config: FilterConfig) {
+    this.filter = new Filter(this.ctx, config);
+  }
+
+  setFilterADSR(config: ADSRConfig, frequencyRange: number = 1.0) {
+    if (this.filter) {
+      this.filter.setFrequencyADSR(config, frequencyRange);
+    }
+  }
+
   // creating the oscillator node on start, instead of constructor
   // allows us to trigger many instances during sequencer lookahead
   start(time: number, destination?: AudioNode) {
-    const { osc, gain } = this.makeOscillator(destination);
+    const { osc, gain } = this.makeOscillator(destination, time);
     osc.start(time);
 
     // Apply envelope if one is set

--- a/package/src/snare.ts
+++ b/package/src/snare.ts
@@ -2,16 +2,19 @@ import { Instrument } from "./instrument";
 import { Oscillator, OscType } from "./oscillator";
 import { Noise } from "./noise";
 import { Envelope } from "./envelope";
+import { FilterConfig } from "./filter";
 
 export interface SnareConfig {
   decay_time: number;
+  filter?: FilterConfig;
+  noiseFilter?: FilterConfig;
 }
 
 export const makeSnare = (
   ctx: AudioContext,
   freq1: number,
   freq2: number,
-  config: SnareConfig = { decay_time: 0.3 }
+  config: SnareConfig = { decay_time: 0.3 },
 ) => {
   const inst = new Instrument(ctx);
 
@@ -43,6 +46,20 @@ export const makeSnare = (
     sustain: 0.0, // Drop to base frequency
     release: config.decay_time * 0.1, // Quick release
   });
+
+  // Add optional filters
+  if (config.filter) {
+    osc1.setFilter(config.filter);
+    osc2.setFilter(config.filter);
+  }
+
+  // Add optional separate filter for noise (different characteristics)
+  if (config.noiseFilter) {
+    noise.setFilter(config.noiseFilter);
+  } else if (config.filter) {
+    // Use the same filter as oscillators if no separate noise filter
+    noise.setFilter(config.filter);
+  }
 
   inst.addGenerator("sub", osc1);
   inst.addGenerator("noise", noise);


### PR DESCRIPTION
## Summary

- Add Filter class with BiquadFilterNode support for all filter types
- Extend Envelope class with applyToFilter() method for cutoff frequency modulation
- Integrate filter support into Oscillator and Noise generators
- Update instrument factories with optional filter configuration
- Add comprehensive TypeScript types and centralized exports
- Maintain full backward compatibility

## Test plan

- [ ] Verify TypeScript compilation
- [ ] Test basic filtering functionality
- [ ] Test ADSR envelope modulation of filter frequency
- [ ] Verify backward compatibility with existing instruments
- [ ] Test different filter types (lowpass, highpass, etc.)

Closes #17

🤖 Generated with [Claude Code](https://claude.ai/code)