### PR TITLE
feat: add overdrive effect system

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -185,9 +185,9 @@ export default function ReactTestPage() {
     }));
     // Propagate param changes
     if (stage) {
-      const params = { ...overdriveSettings.params, ...updates };
+      const params: OverdriveParams = { ...overdriveSettings.params, ...updates };
       ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-        stage.updateInstrumentEffect(name, "Overdrive", params as any),
+        stage.updateInstrumentEffect(name, "Overdrive", params),
       );
     }
   };
@@ -208,9 +208,9 @@ export default function ReactTestPage() {
       params: { ...prev.params, ...updates },
     }));
     if (stage) {
-      const params = { ...reverbSettings.params, ...updates };
+      const params: ReverbParams = { ...reverbSettings.params, ...updates };
       ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-        stage.updateInstrumentEffect(name, "Reverb", params as any),
+        stage.updateInstrumentEffect(name, "Reverb", params),
       );
     }
   };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,8 @@ import { makePinkHat } from "@/package/src/pink-hat";
 import { Sequencer } from "@/package/src/sequencer";
 import { useBeatTracker } from "@/package/src/hooks";
 import { FilterConfig } from "@/package/src/filter";
-import { OverdriveParams } from "../src/audio/effects/OverdriveEffect";
-import { ReverbParams } from "../src/audio/effects/ReverbEffect";
+import { OverdriveParams } from "../package/src/effects/overdrive";
+import { ReverbParams } from "../package/src/effects/reverb";
 
 export default function ReactTestPage() {
   const [patterns, setPatterns] = useState({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,8 @@ import { makePinkHat } from "@/package/src/pink-hat";
 import { Sequencer } from "@/package/src/sequencer";
 import { useBeatTracker } from "@/package/src/hooks";
 import { FilterConfig } from "@/package/src/filter";
-import { OverdriveParams } from "../package/src/effects/overdrive";
-import { ReverbParams } from "../package/src/effects/reverb";
+import { OverdriveParams } from "@/package/src/effects/overdrive";
+import { ReverbParams } from "@/package/src/effects/reverb";
 
 export default function ReactTestPage() {
   const [patterns, setPatterns] = useState({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import { makePinkHat } from "@/package/src/pink-hat";
 import { Sequencer } from "@/package/src/sequencer";
 import { useBeatTracker } from "@/package/src/hooks";
 import { FilterConfig } from "@/package/src/filter";
+import { OverdriveParams } from "../src/audio/effects/OverdriveEffect";
+import { ReverbParams } from "../src/audio/effects/ReverbEffect";
 
 export default function ReactTestPage() {
   const [patterns, setPatterns] = useState({
@@ -58,6 +60,7 @@ export default function ReactTestPage() {
     });
 
   const sequencerRef = useRef<Sequencer | null>(null);
+  // Master-level chain removed; effects are applied per-instrument at creation time
 
   const { currentStep, startBeatTracking, stopBeatTracking } = useBeatTracker({
     audioContext,
@@ -147,17 +150,92 @@ export default function ReactTestPage() {
     }
   };
 
+  // ==== Effects: state and helpers ====
+  const [overdriveSettings, setOverdriveSettings] = useState<{
+    enabled: boolean;
+    params: OverdriveParams;
+  }>({
+    enabled: false,
+    params: { mix: 0.5, drive: 0.75, toneHz: 1200 },
+  });
+
+  const [reverbSettings, setReverbSettings] = useState<{
+    enabled: boolean;
+    params: ReverbParams;
+  }>({
+    enabled: false,
+    params: { mix: 0.25, preDelayMs: 20 },
+  });
+
+  const updateOverdrive = (updates: Partial<OverdriveParams> | { enabled: boolean }) => {
+    if ("enabled" in updates) {
+      const enabled = updates.enabled;
+      setOverdriveSettings((prev) => ({ ...prev, enabled }));
+      // Propagate bypass to existing instruments
+      if (stage) {
+        ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
+          stage.setInstrumentEffectBypassed(name, "Overdrive", !enabled),
+        );
+      }
+      return;
+    }
+    setOverdriveSettings((prev) => ({
+      ...prev,
+      params: { ...prev.params, ...updates },
+    }));
+    // Propagate param changes
+    if (stage) {
+      const params = { ...overdriveSettings.params, ...updates };
+      ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
+        stage.updateInstrumentEffect(name, "Overdrive", params as any),
+      );
+    }
+  };
+
+  const updateReverb = (updates: Partial<ReverbParams> | { enabled: boolean }) => {
+    if ("enabled" in updates) {
+      const enabled = updates.enabled;
+      setReverbSettings((prev) => ({ ...prev, enabled }));
+      if (stage) {
+        ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
+          stage.setInstrumentEffectBypassed(name, "Reverb", !enabled),
+        );
+      }
+      return;
+    }
+    setReverbSettings((prev) => ({
+      ...prev,
+      params: { ...prev.params, ...updates },
+    }));
+    if (stage) {
+      const params = { ...reverbSettings.params, ...updates };
+      ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
+        stage.updateInstrumentEffect(name, "Reverb", params as any),
+      );
+    }
+  };
+
   const triggerKick = () => {
     const ctx = audioContext;
     if (ctx && stage) {
       // Create instruments if they don't exist
       if (!stage.hasInstrument("kick")) {
-        const kick1 = makeKick(ctx, 200, 800);
+        const kick1 = makeKick(ctx, 200, 800, {
+          effects: {
+            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+          },
+        });
         stage.addInstrument("kick", kick1);
       }
 
       if (!stage.hasInstrument("kick2")) {
-        const kick2 = makeKick(ctx, 1500, 2000);
+        const kick2 = makeKick(ctx, 1500, 2000, {
+          effects: {
+            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+          },
+        });
         stage.addInstrument("kick2", kick2);
       }
 
@@ -182,6 +260,10 @@ export default function ReactTestPage() {
       if (!stage.hasInstrument("snare")) {
         const snare1 = makeSnare(ctx, 200, 800, {
           decay_time: 0.3,
+          effects: {
+            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+          },
         });
         stage.addInstrument("snare", snare1);
       }
@@ -201,7 +283,13 @@ export default function ReactTestPage() {
     if (ctx && stage) {
       // Create instrument if it doesn't exist
       if (!stage.hasInstrument("pinkHat")) {
-        const pinkHat1 = makePinkHat(ctx, { decay_time: 0.12 });
+        const pinkHat1 = makePinkHat(ctx, {
+          decay_time: 0.12,
+          effects: {
+            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+          },
+        });
         stage.addInstrument("pinkHat", pinkHat1);
       }
 
@@ -220,20 +308,39 @@ export default function ReactTestPage() {
       const startTime = ctx.currentTime;
 
       // Create instruments without filter configs initially
-      const kick = makeKick(ctx, 50, 300);
+      const kick = makeKick(ctx, 50, 300, {
+        effects: {
+          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+        },
+      });
       stage.addInstrument("kick", kick);
 
       const snare = makeSnare(ctx, 400, 800, {
         decay_time: 0.3,
+        effects: {
+          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+        },
       });
       stage.addInstrument("snare", snare);
 
       const hat = makeSnare(ctx, 200, 800, {
         decay_time: 0.1,
+        effects: {
+          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+        },
       });
       stage.addInstrument("hat", hat);
 
-      const pinkHat = makePinkHat(ctx, { decay_time: 0.1 });
+      const pinkHat = makePinkHat(ctx, {
+        decay_time: 0.1,
+        effects: {
+          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
+          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
+        },
+      });
       stage.addInstrument("pinkHat", pinkHat);
 
       // Apply current filter settings
@@ -361,6 +468,119 @@ export default function ReactTestPage() {
         </button>
       </div>
 
+      <div className="my-6">
+        <h3 className="text-lg font-semibold mb-3">Master Effects</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Overdrive */}
+          <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
+            <div className="flex items-center justify-between mb-3">
+              <div className="font-medium">Overdrive</div>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={overdriveSettings.enabled}
+                  onChange={(e) => updateOverdrive({ enabled: e.target.checked })}
+                />
+                <span className="text-sm text-gray-600">Enable</span>
+              </label>
+            </div>
+            <div className="space-y-3">
+              <div className="flex items-center gap-4">
+                <div className="w-20 text-xs text-gray-600">Mix</div>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={overdriveSettings.params.mix}
+                  onChange={(e) => updateOverdrive({ mix: parseFloat(e.target.value) })}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                />
+                <div className="w-16 text-xs text-gray-600">
+                  {(overdriveSettings.params.mix * 100).toFixed(0)}%
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="w-20 text-xs text-gray-600">Drive</div>
+                <input
+                  type="range"
+                  min="0"
+                  max="1.5"
+                  step="0.01"
+                  value={overdriveSettings.params.drive}
+                  onChange={(e) => updateOverdrive({ drive: parseFloat(e.target.value) })}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                />
+                <div className="w-16 text-xs text-gray-600">
+                  {overdriveSettings.params.drive.toFixed(2)}
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="w-20 text-xs text-gray-600">Tone Hz</div>
+                <input
+                  type="range"
+                  min="100"
+                  max="8000"
+                  step="50"
+                  value={overdriveSettings.params.toneHz}
+                  onChange={(e) => updateOverdrive({ toneHz: parseInt(e.target.value) })}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                />
+                <div className="w-16 text-xs text-gray-600">
+                  {overdriveSettings.params.toneHz}Hz
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Reverb */}
+          <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
+            <div className="flex items-center justify-between mb-3">
+              <div className="font-medium">Reverb</div>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={reverbSettings.enabled}
+                  onChange={(e) => updateReverb({ enabled: e.target.checked })}
+                />
+                <span className="text-sm text-gray-600">Enable</span>
+              </label>
+            </div>
+            <div className="space-y-3">
+              <div className="flex items-center gap-4">
+                <div className="w-20 text-xs text-gray-600">Mix</div>
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={reverbSettings.params.mix}
+                  onChange={(e) => updateReverb({ mix: parseFloat(e.target.value) })}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                />
+                <div className="w-16 text-xs text-gray-600">
+                  {(reverbSettings.params.mix * 100).toFixed(0)}%
+                </div>
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="w-20 text-xs text-gray-600">PreDelay</div>
+                <input
+                  type="range"
+                  min="0"
+                  max="200"
+                  step="1"
+                  value={reverbSettings.params.preDelayMs}
+                  onChange={(e) => updateReverb({ preDelayMs: parseInt(e.target.value) })}
+                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                />
+                <div className="w-16 text-xs text-gray-600">
+                  {reverbSettings.params.preDelayMs}ms
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="my-6">
         <h3 className="text-lg font-semibold mb-3">Sequencer Pattern</h3>
         <div className="space-y-2">

--- a/package/src/effects/AudioEffect.ts
+++ b/package/src/effects/AudioEffect.ts
@@ -1,0 +1,13 @@
+export interface AudioEffect<P extends Record<string, unknown>> {
+  readonly name: string;
+  readonly input: AudioNode;
+  readonly output: AudioNode;
+  setMix(mix: number): void;
+  setBypassed(bypassed: boolean): void;
+  update(params: Partial<P>): void;
+  remove(): void;
+}
+
+export type EffectParams<E extends AudioEffect<any>> = E extends AudioEffect<infer P>
+  ? P
+  : never;

--- a/package/src/effects/EffectChain.ts
+++ b/package/src/effects/EffectChain.ts
@@ -1,0 +1,87 @@
+import { AudioEffect, EffectParams } from './AudioEffect';
+import { EffectName, EffectParamsForName, PartialEffectParams, EffectClassForName } from './EffectRegistry';
+
+export class EffectChain {
+  readonly input: GainNode;
+  readonly output: GainNode;
+
+  private readonly ctx: AudioContext;
+  private effects: AudioEffect<any>[] = [];
+
+  constructor(ctx: AudioContext) {
+    this.ctx = ctx;
+    this.input = new GainNode(ctx);
+    this.output = new GainNode(ctx);
+    this.input.connect(this.output);
+  }
+
+  add(effect: AudioEffect<any>, index = this.effects.length) {
+    this.effects.splice(index, 0, effect);
+    this.rebuild();
+  }
+
+  move(effect: AudioEffect<any>, newIndex: number) {
+    const i = this.effects.indexOf(effect);
+    if (i < 0) return;
+    this.effects.splice(i, 1);
+    this.effects.splice(newIndex, 0, effect);
+    this.rebuild();
+  }
+
+  remove(effect: AudioEffect<any>) {
+    const i = this.effects.indexOf(effect);
+    if (i < 0) return;
+    this.effects.splice(i, 1);
+    this.rebuild();
+    effect.remove();
+  }
+
+  setBypassed(effect: AudioEffect<any>, bypassed: boolean) {
+    effect.setBypassed(bypassed);
+  }
+
+  update<E extends AudioEffect<any>>(effect: E, params: Partial<EffectParams<E>>) {
+    effect.update(params as Partial<EffectParams<E>>);
+  }
+
+  findByName<T extends EffectName>(name: T): EffectClassForName<T> | undefined {
+    return this.effects.find((e) => e.name === name) as EffectClassForName<T> | undefined;
+  }
+
+  // Generic version for cases where effect name is not known at compile time
+  findByNameGeneric(name: string): AudioEffect<any> | undefined {
+    return this.effects.find((e) => e.name === name);
+  }
+
+  setBypassedByName(name: string, bypassed: boolean) {
+    const effect = this.findByNameGeneric(name);
+    if (effect) effect.setBypassed(bypassed);
+  }
+
+  updateByName<T extends EffectName>(name: T, params: PartialEffectParams<T>) {
+    const effect = this.findByName(name);
+    if (effect) effect.update(params);
+  }
+
+  // TODO
+  // shouldn't be called during runtime because we have bypass
+  // it could make more sense to have a .build() method to defer connecting nodes
+  // on each change 
+  // may also be insignificant performance hit at setup time
+  private rebuild() {
+    this.input.disconnect();
+    // IMPORTANT: Do not disconnect effect.input here, as many effects wire their
+    // internal graph from effect.input in their constructors. Disconnecting it
+    // would sever that internal wiring. Only disconnect the outputs which are
+    // the connections we (the chain) created.
+    for (const e of this.effects) {
+      e.output.disconnect();
+    }
+    let head: AudioNode = this.input;
+    for (const e of this.effects) {
+      head.connect(e.input);
+      head = e.output;
+    }
+    head.connect(this.output);
+  }
+}

--- a/package/src/effects/EffectRegistry.ts
+++ b/package/src/effects/EffectRegistry.ts
@@ -1,0 +1,28 @@
+import { OverdriveParams, OverdriveEffect } from './overdrive';
+import { ReverbParams, ConvolverReverbEffect } from './reverb';
+
+// Registry mapping effect names to their parameter types
+export interface EffectParamsRegistry {
+  'Overdrive': OverdriveParams;
+  'Reverb': ReverbParams;
+  // Add more effects here as they are created
+}
+
+// Registry mapping effect names to their effect class types
+export interface EffectClassRegistry {
+  'Overdrive': OverdriveEffect;
+  'Reverb': ConvolverReverbEffect;
+  // Add more effects here as they are created
+}
+
+// Helper type to get parameter type from effect name
+export type EffectParamsForName<T extends keyof EffectParamsRegistry> = EffectParamsRegistry[T];
+
+// Helper type to get effect class type from effect name
+export type EffectClassForName<T extends keyof EffectClassRegistry> = EffectClassRegistry[T];
+
+// Union of all valid effect names
+export type EffectName = keyof EffectParamsRegistry;
+
+// Helper type for partial parameters (used in updates)
+export type PartialEffectParams<T extends EffectName> = Partial<EffectParamsForName<T>>;

--- a/package/src/effects/SingleInOutEffect.ts
+++ b/package/src/effects/SingleInOutEffect.ts
@@ -1,0 +1,97 @@
+import { AudioEffect } from "./AudioEffect";
+
+export abstract class SingleInOutEffect<P extends Record<string, unknown>>
+  implements AudioEffect<P>
+{
+  readonly name: string;
+
+  readonly input: GainNode;
+  readonly output: GainNode;
+
+  protected readonly splitGain: GainNode;
+  protected readonly dryGain: GainNode;
+  protected readonly wetGain: GainNode;
+  protected readonly sumGain: GainNode;
+
+  private bypassed = false;
+  private currentMix: number;
+  private readonly ctx: AudioContext;
+  private coreIn?: AudioNode;
+  private coreOut?: AudioNode;
+
+  constructor(ctx: AudioContext, name: string, initialMix = 0.5) {
+    this.ctx = ctx;
+    this.name = name;
+    this.currentMix = Math.min(1, Math.max(0, initialMix));
+
+    this.input = new GainNode(ctx);
+    this.output = new GainNode(ctx);
+
+    this.splitGain = new GainNode(ctx);
+    this.dryGain = new GainNode(ctx, { gain: 1 - this.currentMix });
+    this.wetGain = new GainNode(ctx, { gain: this.currentMix });
+    this.sumGain = new GainNode(ctx);
+
+    this.input.connect(this.splitGain);
+    this.splitGain.connect(this.dryGain);
+    this.dryGain.connect(this.sumGain);
+    this.sumGain.connect(this.output);
+
+    // Wet path will be wired by subclass via initializeEffectCore
+    this.wetGain.connect(this.sumGain);
+  }
+
+  protected get audioContext(): AudioContext {
+    return this.ctx;
+  }
+
+  /**
+   * Call this from the subclass constructor after creating the effect's core nodes
+   * to wire the wet path: split -> effectIn -> effectOut -> wet -> sum.
+   */
+  protected initializeEffectCore(effectInput: AudioNode, effectOutput: AudioNode) {
+    // Disconnect any previous wiring if re-initializing
+    if (this.coreIn) this.splitGain.disconnect(this.coreIn);
+    if (this.coreOut) this.coreOut.disconnect(this.wetGain);
+
+    this.coreIn = effectInput;
+    this.coreOut = effectOutput;
+
+    this.splitGain.connect(this.coreIn);
+    this.coreOut.connect(this.wetGain);
+  }
+
+  setMix(mix: number) {
+    const mixAmt = Math.min(1, Math.max(0, mix));
+    this.currentMix = mixAmt;
+    this.wetGain.gain.value = this.bypassed ? 0 : this.currentMix;
+    this.dryGain.gain.value = 1 - this.currentMix;
+  }
+
+  setBypassed(bypassed: boolean) {
+    this.bypassed = bypassed;
+    if (bypassed) {
+      this.wetGain.gain.value = 0;
+      this.dryGain.gain.value = 1;
+    } else {
+      // Restore wet/dry based on current mix when un-bypassing
+      this.wetGain.gain.value = this.currentMix;
+      this.dryGain.gain.value = 1 - this.currentMix;
+    }
+  }
+
+  // default no-op; subclasses override
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  update(_: Partial<P>) {}
+
+  remove() {
+    this.input.disconnect();
+    this.output.disconnect();
+    this.splitGain.disconnect();
+    this.dryGain.disconnect();
+    this.wetGain.disconnect();
+    this.sumGain.disconnect();
+    if (this.coreIn) this.coreIn.disconnect();
+    if (this.coreOut) this.coreOut.disconnect();
+  }
+}

--- a/package/src/effects/index.ts
+++ b/package/src/effects/index.ts
@@ -1,0 +1,1 @@
+export { Overdrive, OverdriveConfig } from "./overdrive";

--- a/package/src/effects/index.ts
+++ b/package/src/effects/index.ts
@@ -1,1 +1,12 @@
-export { Overdrive, OverdriveConfig } from "./overdrive";
+// Re-export all effects for convenient importing
+export type { AudioEffect, EffectParams } from './AudioEffect';
+export { SingleInOutEffect } from './SingleInOutEffect';
+export { OverdriveEffect, type OverdriveParams } from './overdrive';
+export { ConvolverReverbEffect, type ReverbParams } from './reverb';
+export { EffectChain } from './EffectChain';
+export type { 
+  EffectName, 
+  EffectParamsForName, 
+  EffectClassForName, 
+  PartialEffectParams 
+} from './EffectRegistry';

--- a/package/src/effects/overdrive.ts
+++ b/package/src/effects/overdrive.ts
@@ -8,7 +8,7 @@ export class Overdrive {
 
   constructor(ctx: AudioContext, config: OverdriveConfig = {}) {
     this.ctx = ctx;
-    this.node = createMaxOverdrive(ctx, config.drive);
+    this.node = this.createOverdriveNode(config.drive || 1);
   }
 
   getNode(): WaveShaperNode {
@@ -16,25 +16,25 @@ export class Overdrive {
   }
 
   setDrive(drive: number) {
-    this.node.curve = makeMaxOverdriveCurve(drive);
+    this.node.curve = this.createOverdriveCurve(drive);
   }
-}
 
-function createMaxOverdrive(context: AudioContext, drive = 1): WaveShaperNode {
-  const node = context.createWaveShaper();
-  node.curve = makeMaxOverdriveCurve(drive);
-  node.oversample = "4x"; // helps reduce aliasing
-  return node;
-}
-
-function makeMaxOverdriveCurve(drive: number): Float32Array {
-  const samples = 44100;
-  const curve = new Float32Array(samples);
-  const g = Math.max(1, drive); // match zmap 1–10 range
-  for (let i = 0; i < samples; i++) {
-    const x = (i * 2) / samples - 1; // -1 to 1
-    // Max overdrive~ style: pre-gain then arctangent soft clip
-    curve[i] = (2 / Math.PI) * Math.atan(g * x);
+  private createOverdriveNode(drive: number): WaveShaperNode {
+    const node = this.ctx.createWaveShaper();
+    node.curve = this.createOverdriveCurve(drive);
+    node.oversample = "4x"; // helps reduce aliasing
+    return node;
   }
-  return curve;
+
+  private createOverdriveCurve(drive: number): Float32Array {
+    const samples = 44100;
+    const curve = new Float32Array(samples);
+    const g = Math.max(1, drive);
+    for (let i = 0; i < samples; i++) {
+      const x = (i * 2) / samples - 1; // -1 to 1
+      // Pre-gain then arctangent soft clipping
+      curve[i] = (2 / Math.PI) * Math.atan(g * x);
+    }
+    return curve;
+  }
 }

--- a/package/src/effects/overdrive.ts
+++ b/package/src/effects/overdrive.ts
@@ -1,0 +1,40 @@
+export interface OverdriveConfig {
+  drive?: number;
+}
+
+export class Overdrive {
+  private ctx: AudioContext;
+  private node: WaveShaperNode;
+
+  constructor(ctx: AudioContext, config: OverdriveConfig = {}) {
+    this.ctx = ctx;
+    this.node = createMaxOverdrive(ctx, config.drive);
+  }
+
+  getNode(): WaveShaperNode {
+    return this.node;
+  }
+
+  setDrive(drive: number) {
+    this.node.curve = makeMaxOverdriveCurve(drive);
+  }
+}
+
+function createMaxOverdrive(context: AudioContext, drive = 1): WaveShaperNode {
+  const node = context.createWaveShaper();
+  node.curve = makeMaxOverdriveCurve(drive);
+  node.oversample = "4x"; // helps reduce aliasing
+  return node;
+}
+
+function makeMaxOverdriveCurve(drive: number): Float32Array {
+  const samples = 44100;
+  const curve = new Float32Array(samples);
+  const g = Math.max(1, drive); // match zmap 1–10 range
+  for (let i = 0; i < samples; i++) {
+    const x = (i * 2) / samples - 1; // -1 to 1
+    // Max overdrive~ style: pre-gain then arctangent soft clip
+    curve[i] = (2 / Math.PI) * Math.atan(g * x);
+  }
+  return curve;
+}

--- a/package/src/effects/reverb.ts
+++ b/package/src/effects/reverb.ts
@@ -1,0 +1,85 @@
+import { SingleInOutEffect } from './SingleInOutEffect';
+
+export type ReverbParams = {
+  mix: number; // 0..1
+  preDelayMs: number; // >= 0
+};
+
+export class ConvolverReverbEffect extends SingleInOutEffect<ReverbParams> {
+  private readonly convolver: ConvolverNode;
+  private preDelay?: DelayNode;
+
+  constructor(
+    ctx: AudioContext,
+    private impulseBuffer?: AudioBuffer,
+    opts: Partial<ReverbParams> = {}
+  ) {
+    super(ctx, 'Reverb', opts.mix ?? 0.3);
+    this.convolver = new ConvolverNode(ctx);
+    if (this.impulseBuffer) {
+      this.convolver.buffer = this.impulseBuffer;
+    } else {
+      // Provide a simple default impulse response so the effect is audible
+      this.convolver.buffer = createDefaultImpulseResponse(ctx, 2.0, 2.0);
+    }
+
+    // set up wet path depending on predelay
+    if (this.preDelay) {
+      this.preDelay.connect(this.convolver);
+      this.initializeEffectCore(this.preDelay, this.convolver);
+    } else {
+      this.initializeEffectCore(this.convolver, this.convolver);
+    }
+    this.update({
+      mix: opts.mix ?? 0.3,
+      preDelayMs: opts.preDelayMs ?? 0,
+    });
+  }
+
+  setImpulse(buffer: AudioBuffer) {
+    this.impulseBuffer = buffer;
+    if (this.convolver) this.convolver.buffer = buffer;
+  }
+
+  update(params: Partial<ReverbParams>) {
+    if (params.mix !== undefined) this.setMix(params.mix);
+
+    if (params.preDelayMs !== undefined) {
+      const value = Math.max(0, params.preDelayMs) / 1000;
+      if (!this.preDelay) {
+        this.preDelay = new DelayNode(this.audioContext, { delayTime: value });
+        // Rewire: split -> preDelay -> convolver
+        this.preDelay.connect(this.convolver);
+        this.initializeEffectCore(this.preDelay, this.convolver);
+      } else {
+        this.preDelay.delayTime.value = value;
+      }
+    }
+  }
+
+  remove() {
+    super.remove();
+    if (this.convolver) this.convolver.buffer = null;
+  }
+}
+
+function createDefaultImpulseResponse(
+  ctx: AudioContext,
+  durationSeconds = 1.5,
+  decay = 2.0,
+) {
+  const rate = ctx.sampleRate;
+  const length = Math.max(1, Math.floor(durationSeconds * rate));
+  const ir = ctx.createBuffer(2, length, rate);
+
+  for (let channel = 0; channel < ir.numberOfChannels; channel++) {
+    const data = ir.getChannelData(channel);
+    for (let i = 0; i < length; i++) {
+      // Exponential decay noise
+      const t = i / length;
+      data[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, decay);
+    }
+  }
+
+  return ir;
+}

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -3,7 +3,7 @@ export { Oscillator, OscType } from "./oscillator";
 export { Noise } from "./generators";
 export { Envelope, type ADSRConfig } from "./envelope";
 export { Filter, type FilterConfig } from "./filter";
-export { Overdrive, type OverdriveConfig } from "./effects";
+export { OverdriveEffect as Overdrive, type OverdriveParams as OverdriveConfig } from "./effects";
 
 // Instrument and composition
 export { Instrument } from "./instrument";

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -3,6 +3,7 @@ export { Oscillator, OscType } from "./oscillator";
 export { Noise } from "./generators";
 export { Envelope, type ADSRConfig } from "./envelope";
 export { Filter, type FilterConfig } from "./filter";
+export { Overdrive, type OverdriveConfig } from "./effects";
 
 // Instrument and composition
 export { Instrument } from "./instrument";

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -1,5 +1,6 @@
 import { Oscillator } from "./oscillator";
 import { Noise, WhiteNoise, PinkNoise } from "./generators";
+import { OverdriveConfig } from "./effects";
 
 // Define a type for any generator (Oscillator or Noise)
 export type AudioGenerator = Oscillator | Noise | WhiteNoise | PinkNoise;
@@ -54,6 +55,22 @@ export class Instrument {
         }
       }
     }
+  }
+
+  // Apply overdrive effect to all oscillators in this instrument
+  setOverdrive(config: OverdriveConfig | undefined) {
+    for (const key in this.generators) {
+      if (this.generators.hasOwnProperty(key)) {
+        const gen = this.generators[key].gen;
+        if (gen instanceof Oscillator) {
+          gen.setOverdrive(config);
+        }
+      }
+    }
+  }
+
+  removeOverdrive() {
+    this.setOverdrive(undefined);
   }
 }
 

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -1,9 +1,8 @@
 import { Oscillator } from "./oscillator";
 import { Noise, WhiteNoise, PinkNoise } from "./generators";
-import { OverdriveConfig } from "./effects";
-import { EffectChain } from "../../src/audio/effects/EffectChain";
-import { AudioEffect } from "../../src/audio/effects/AudioEffect";
-import { EffectName, PartialEffectParams } from "../../src/audio/effects/EffectRegistry";
+import { EffectChain } from "./effects/EffectChain";
+import { AudioEffect } from "./effects/AudioEffect";
+import { EffectName, PartialEffectParams } from "./effects/EffectRegistry";
 
 // Define a type for any generator (Oscillator or Noise)
 export type AudioGenerator = Oscillator | Noise | WhiteNoise | PinkNoise;
@@ -94,28 +93,7 @@ export class Instrument {
     }
   }
 
-  // Apply overdrive effect to all oscillators in this instrument
-  setOverdrive(config: OverdriveConfig) {
-    for (const key in this.generators) {
-      if (this.generators.hasOwnProperty(key)) {
-        const gen = this.generators[key].gen;
-        if (gen instanceof Oscillator) {
-          gen.setOverdrive(config);
-        }
-      }
-    }
-  }
 
-  removeOverdrive() {
-    for (const key in this.generators) {
-      if (this.generators.hasOwnProperty(key)) {
-        const gen = this.generators[key].gen;
-        if (gen instanceof Oscillator) {
-          gen.removeOverdrive();
-        }
-      }
-    }
-  }
 }
 
 // export class OneShot extends Instrument {

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -58,7 +58,7 @@ export class Instrument {
   }
 
   // Apply overdrive effect to all oscillators in this instrument
-  setOverdrive(config: OverdriveConfig | undefined) {
+  setOverdrive(config: OverdriveConfig) {
     for (const key in this.generators) {
       if (this.generators.hasOwnProperty(key)) {
         const gen = this.generators[key].gen;
@@ -70,7 +70,14 @@ export class Instrument {
   }
 
   removeOverdrive() {
-    this.setOverdrive(undefined);
+    for (const key in this.generators) {
+      if (this.generators.hasOwnProperty(key)) {
+        const gen = this.generators[key].gen;
+        if (gen instanceof Oscillator) {
+          gen.removeOverdrive();
+        }
+      }
+    }
   }
 }
 

--- a/package/src/instrument.ts
+++ b/package/src/instrument.ts
@@ -3,6 +3,7 @@ import { Noise, WhiteNoise, PinkNoise } from "./generators";
 import { OverdriveConfig } from "./effects";
 import { EffectChain } from "../../src/audio/effects/EffectChain";
 import { AudioEffect } from "../../src/audio/effects/AudioEffect";
+import { EffectName, PartialEffectParams } from "../../src/audio/effects/EffectRegistry";
 
 // Define a type for any generator (Oscillator or Noise)
 export type AudioGenerator = Oscillator | Noise | WhiteNoise | PinkNoise;
@@ -49,7 +50,7 @@ export class Instrument {
     this.effectChain.setBypassedByName(effectName, bypassed);
   }
 
-  updateEffect(effectName: string, params: Record<string, unknown>) {
+  updateEffect<T extends EffectName>(effectName: T, params: PartialEffectParams<T>) {
     if (!this.effectChain) return;
     this.effectChain.updateByName(effectName, params);
   }

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -2,10 +2,8 @@ import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
 import { Noise } from "./generators";
 import { FilterConfig } from "./filter";
-import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
-import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
-import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
-import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
+import { OverdriveEffect, OverdriveParams } from "./effects/overdrive";
+import { ConvolverReverbEffect, ReverbParams } from "./effects/reverb";
 
 export interface KickConfig {
   filter?: FilterConfig;

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -4,13 +4,15 @@ import { Noise } from "./generators";
 import { FilterConfig } from "./filter";
 import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
 import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
+import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
+import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
 
 export interface KickConfig {
   filter?: FilterConfig;
   clickFilter?: FilterConfig;
   effects?: {
-    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
-    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+    overdrive?: Partial<OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<ReverbParams> & { enabled?: boolean };
   };
 }
 

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -2,17 +2,19 @@ import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
 import { Noise } from "./generators";
 import { FilterConfig } from "./filter";
+import { OverdriveConfig } from "./effects";
 
 export interface KickConfig {
   filter?: FilterConfig;
   clickFilter?: FilterConfig;
+  overdrive?: OverdriveConfig;
 }
 
 export const makeKick = (
   ctx: AudioContext,
   freq1: number,
   freq2: number,
-  config?: KickConfig
+  config?: KickConfig,
 ) => {
   const inst = new Instrument(ctx);
 
@@ -38,6 +40,12 @@ export const makeKick = (
   if (config?.filter) {
     osc1.setFilter(config.filter);
     osc2.setFilter(config.filter);
+  }
+
+  // Add optional overdrive to oscillators
+  if (config?.overdrive) {
+    osc1.setOverdrive(config.overdrive);
+    osc2.setOverdrive(config.overdrive);
   }
 
   // Add short "click" sound using noise generator

--- a/package/src/kick.ts
+++ b/package/src/kick.ts
@@ -2,19 +2,23 @@ import { Instrument } from "./instrument";
 import { Oscillator } from "./oscillator";
 import { Noise } from "./generators";
 import { FilterConfig } from "./filter";
-import { OverdriveConfig } from "./effects";
+import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
+import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
 
 export interface KickConfig {
   filter?: FilterConfig;
   clickFilter?: FilterConfig;
-  overdrive?: OverdriveConfig;
+  effects?: {
+    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+  };
 }
 
 export const makeKick = (
   ctx: AudioContext,
   freq1: number,
   freq2: number,
-  config?: KickConfig,
+  config?: KickConfig
 ) => {
   const inst = new Instrument(ctx);
 
@@ -42,12 +46,6 @@ export const makeKick = (
     osc2.setFilter(config.filter);
   }
 
-  // Add optional overdrive to oscillators
-  if (config?.overdrive) {
-    osc1.setOverdrive(config.overdrive);
-    osc2.setOverdrive(config.overdrive);
-  }
-
   // Add short "click" sound using noise generator
   const clickNoise = new Noise(ctx);
 
@@ -66,6 +64,20 @@ export const makeKick = (
   inst.addGenerator("sub", osc1);
   inst.addGenerator("main", osc2);
   inst.addGenerator("click", clickNoise);
+
+  // Optional per-instrument effects
+  if (config?.effects) {
+    if (config.effects.overdrive) {
+      const od = new OverdriveEffect(ctx, config.effects.overdrive);
+      od.setBypassed(!config.effects.overdrive.enabled);
+      inst.addEffect(od);
+    }
+    if (config.effects.reverb) {
+      const rv = new ConvolverReverbEffect(ctx, undefined, config.effects.reverb);
+      rv.setBypassed(!config.effects.reverb.enabled);
+      inst.addEffect(rv);
+    }
+  }
 
   return inst;
 };

--- a/package/src/oscillator.ts
+++ b/package/src/oscillator.ts
@@ -103,8 +103,8 @@ export class Oscillator {
     }
   }
 
-  setOverdrive(config: OverdriveConfig | undefined) {
-    this.overdrive = config ? new Overdrive(this.ctx, config) : undefined;
+  setOverdrive(config: OverdriveConfig) {
+    this.overdrive = new Overdrive(this.ctx, config);
   }
 
   removeOverdrive() {

--- a/package/src/pink-hat.ts
+++ b/package/src/pink-hat.ts
@@ -1,9 +1,7 @@
 import { Instrument } from "./instrument";
 import { PinkNoise } from "./generators";
-import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
-import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
-import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
-import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
+import { OverdriveEffect, OverdriveParams } from "./effects/overdrive";
+import { ConvolverReverbEffect, ReverbParams } from "./effects/reverb";
 
 export interface PinkHatConfig {
   decay_time: number;

--- a/package/src/pink-hat.ts
+++ b/package/src/pink-hat.ts
@@ -1,8 +1,14 @@
 import { Instrument } from "./instrument";
 import { PinkNoise } from "./generators";
+import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
+import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
 
 export interface PinkHatConfig {
   decay_time: number;
+  effects?: {
+    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+  };
 }
 
 export const makePinkHat = (
@@ -22,6 +28,20 @@ export const makePinkHat = (
   });
 
   inst.addGenerator("pink", pinkNoise);
+
+  // Optional per-instrument effects
+  if (config.effects) {
+    if (config.effects.overdrive) {
+      const od = new OverdriveEffect(ctx, config.effects.overdrive);
+      od.setBypassed(!config.effects.overdrive.enabled);
+      inst.addEffect(od);
+    }
+    if (config.effects.reverb) {
+      const rv = new ConvolverReverbEffect(ctx, undefined, config.effects.reverb);
+      rv.setBypassed(!config.effects.reverb.enabled);
+      inst.addEffect(rv);
+    }
+  }
 
   return inst;
 };

--- a/package/src/pink-hat.ts
+++ b/package/src/pink-hat.ts
@@ -2,12 +2,14 @@ import { Instrument } from "./instrument";
 import { PinkNoise } from "./generators";
 import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
 import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
+import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
+import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
 
 export interface PinkHatConfig {
   decay_time: number;
   effects?: {
-    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
-    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+    overdrive?: Partial<OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<ReverbParams> & { enabled?: boolean };
   };
 }
 

--- a/package/src/snare.ts
+++ b/package/src/snare.ts
@@ -3,10 +3,8 @@ import { Oscillator, OscType } from "./oscillator";
 import { Noise } from "./generators";
 import { Envelope } from "./envelope";
 import { FilterConfig } from "./filter";
-import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
-import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
-import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
-import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
+import { OverdriveEffect, OverdriveParams } from "./effects/overdrive";
+import { ConvolverReverbEffect, ReverbParams } from "./effects/reverb";
 
 export interface SnareConfig {
   decay_time: number;

--- a/package/src/snare.ts
+++ b/package/src/snare.ts
@@ -5,14 +5,16 @@ import { Envelope } from "./envelope";
 import { FilterConfig } from "./filter";
 import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
 import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
+import type { OverdriveParams } from "../../src/audio/effects/OverdriveEffect";
+import type { ReverbParams } from "../../src/audio/effects/ReverbEffect";
 
 export interface SnareConfig {
   decay_time: number;
   filter?: FilterConfig;
   noiseFilter?: FilterConfig;
   effects?: {
-    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
-    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+    overdrive?: Partial<OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<ReverbParams> & { enabled?: boolean };
   };
 }
 

--- a/package/src/snare.ts
+++ b/package/src/snare.ts
@@ -3,11 +3,17 @@ import { Oscillator, OscType } from "./oscillator";
 import { Noise } from "./generators";
 import { Envelope } from "./envelope";
 import { FilterConfig } from "./filter";
+import { OverdriveEffect } from "../../src/audio/effects/OverdriveEffect";
+import { ConvolverReverbEffect } from "../../src/audio/effects/ReverbEffect";
 
 export interface SnareConfig {
   decay_time: number;
   filter?: FilterConfig;
   noiseFilter?: FilterConfig;
+  effects?: {
+    overdrive?: Partial<import("../../src/audio/effects/OverdriveEffect").OverdriveParams> & { enabled?: boolean };
+    reverb?: Partial<import("../../src/audio/effects/ReverbEffect").ReverbParams> & { enabled?: boolean };
+  };
 }
 
 export const makeSnare = (
@@ -64,6 +70,20 @@ export const makeSnare = (
   inst.addGenerator("sub", osc1);
   inst.addGenerator("noise", noise);
   inst.addGenerator("tone", osc2);
+
+  // Optional per-instrument effects
+  if (config.effects) {
+    if (config.effects.overdrive) {
+      const od = new OverdriveEffect(ctx, config.effects.overdrive);
+      od.setBypassed(!config.effects.overdrive.enabled);
+      inst.addEffect(od);
+    }
+    if (config.effects.reverb) {
+      const rv = new ConvolverReverbEffect(ctx, undefined, config.effects.reverb);
+      rv.setBypassed(!config.effects.reverb.enabled);
+      inst.addEffect(rv);
+    }
+  }
 
   return inst;
 };

--- a/package/src/stage.ts
+++ b/package/src/stage.ts
@@ -1,6 +1,6 @@
 import { Instrument } from "@/package/src/instrument";
 import { FilterConfig } from "@/package/src/filter";
-import { EffectName, PartialEffectParams } from "../../src/audio/effects/EffectRegistry";
+import { EffectName, PartialEffectParams } from "./effects/EffectRegistry";
 
 type InstrumentChannel = {
   instrument: Instrument;

--- a/package/src/stage.ts
+++ b/package/src/stage.ts
@@ -1,5 +1,6 @@
 import { Instrument } from "@/package/src/instrument";
 import { FilterConfig } from "@/package/src/filter";
+import { EffectName, PartialEffectParams } from "../../src/audio/effects/EffectRegistry";
 
 type InstrumentChannel = {
   instrument: Instrument;
@@ -52,7 +53,7 @@ export class Stage {
     instChannel.instrument.setEffectBypassed(effectName, bypassed);
   }
 
-  updateInstrumentEffect(name: string, effectName: string, params: Record<string, unknown>) {
+  updateInstrumentEffect<T extends EffectName>(name: string, effectName: T, params: PartialEffectParams<T>) {
     const instChannel = this.instruments[name];
     if (!instChannel) return;
     instChannel.instrument.updateEffect(effectName, params);

--- a/package/src/stage.ts
+++ b/package/src/stage.ts
@@ -45,6 +45,19 @@ export class Stage {
     };
   }
 
+  // Convenience helpers to toggle/update per-instrument effects that were added at construction
+  setInstrumentEffectBypassed(name: string, effectName: string, bypassed: boolean) {
+    const instChannel = this.instruments[name];
+    if (!instChannel) return;
+    instChannel.instrument.setEffectBypassed(effectName, bypassed);
+  }
+
+  updateInstrumentEffect(name: string, effectName: string, params: Record<string, unknown>) {
+    const instChannel = this.instruments[name];
+    if (!instChannel) return;
+    instChannel.instrument.updateEffect(effectName, params);
+  }
+
   // TODO
   // check that name exists
   trigger(name: string) {

--- a/src/audio/effects/AudioEffect.ts
+++ b/src/audio/effects/AudioEffect.ts
@@ -1,0 +1,15 @@
+export interface AudioEffect<P extends Record<string, unknown>> {
+  readonly name: string;
+  readonly input: AudioNode;
+  readonly output: AudioNode;
+  setMix(mix: number): void;
+  setBypassed(bypassed: boolean): void;
+  update(params: Partial<P>): void;
+  remove(): void;
+}
+
+export type EffectParams<E extends AudioEffect<any>> = E extends AudioEffect<infer P>
+  ? P
+  : never;
+
+

--- a/src/audio/effects/EffectChain.ts
+++ b/src/audio/effects/EffectChain.ts
@@ -1,0 +1,78 @@
+import { AudioEffect, EffectParams } from './AudioEffect';
+
+export class EffectChain {
+  readonly input: GainNode;
+  readonly output: GainNode;
+
+  private readonly ctx: AudioContext;
+  private effects: AudioEffect<any>[] = [];
+
+  constructor(ctx: AudioContext) {
+    this.ctx = ctx;
+    this.input = new GainNode(ctx);
+    this.output = new GainNode(ctx);
+    this.input.connect(this.output);
+  }
+
+  add(effect: AudioEffect<any>, index = this.effects.length) {
+    this.effects.splice(index, 0, effect);
+    this.rebuild();
+  }
+
+  move(effect: AudioEffect<any>, newIndex: number) {
+    const i = this.effects.indexOf(effect);
+    if (i < 0) return;
+    this.effects.splice(i, 1);
+    this.effects.splice(newIndex, 0, effect);
+    this.rebuild();
+  }
+
+  remove(effect: AudioEffect<any>) {
+    const i = this.effects.indexOf(effect);
+    if (i < 0) return;
+    this.effects.splice(i, 1);
+    this.rebuild();
+    effect.remove();
+  }
+
+  setBypassed(effect: AudioEffect<any>, bypassed: boolean) {
+    effect.setBypassed(bypassed);
+  }
+
+  update<E extends AudioEffect<any>>(effect: E, params: Partial<EffectParams<E>>) {
+    effect.update(params as Partial<EffectParams<E>>);
+  }
+
+  findByName<T extends AudioEffect<any> = AudioEffect<any>>(name: string): T | undefined {
+    return this.effects.find((e) => e.name === name) as T | undefined;
+  }
+
+  setBypassedByName(name: string, bypassed: boolean) {
+    const effect = this.findByName(name);
+    if (effect) effect.setBypassed(bypassed);
+  }
+
+  updateByName(name: string, params: Record<string, unknown>) {
+    const effect = this.findByName(name);
+    if (effect) effect.update(params as any);
+  }
+
+  private rebuild() {
+    this.input.disconnect();
+    // IMPORTANT: Do not disconnect effect.input here, as many effects wire their
+    // internal graph from effect.input in their constructors. Disconnecting it
+    // would sever that internal wiring. Only disconnect the outputs which are
+    // the connections we (the chain) created.
+    for (const e of this.effects) {
+      e.output.disconnect();
+    }
+    let head: AudioNode = this.input;
+    for (const e of this.effects) {
+      head.connect(e.input);
+      head = e.output;
+    }
+    head.connect(this.output);
+  }
+}
+
+

--- a/src/audio/effects/EffectRegistry.ts
+++ b/src/audio/effects/EffectRegistry.ts
@@ -1,0 +1,29 @@
+import { OverdriveParams, OverdriveEffect } from './OverdriveEffect';
+import { ReverbParams, ConvolverReverbEffect } from './ReverbEffect';
+// import { AudioEffect } from './AudioEffect';
+
+// Registry mapping effect names to their parameter types
+export interface EffectParamsRegistry {
+  'Overdrive': OverdriveParams;
+  'Reverb': ReverbParams;
+  // Add more effects here as they are created
+}
+
+// Registry mapping effect names to their effect class types
+export interface EffectClassRegistry {
+  'Overdrive': OverdriveEffect;
+  'Reverb': ConvolverReverbEffect;
+  // Add more effects here as they are created
+}
+
+// Helper type to get parameter type from effect name
+export type EffectParamsForName<T extends keyof EffectParamsRegistry> = EffectParamsRegistry[T];
+
+// Helper type to get effect class type from effect name
+export type EffectClassForName<T extends keyof EffectClassRegistry> = EffectClassRegistry[T];
+
+// Union of all valid effect names
+export type EffectName = keyof EffectParamsRegistry;
+
+// Helper type for partial parameters (used in updates)
+export type PartialEffectParams<T extends EffectName> = Partial<EffectParamsForName<T>>;

--- a/src/audio/effects/OverdriveEffect.ts
+++ b/src/audio/effects/OverdriveEffect.ts
@@ -1,0 +1,57 @@
+import { SingleInOutEffect } from './SingleInOutEffect';
+
+export type OverdriveParams = {
+  mix: number; // 0..1
+  drive: number; // 0..1.5
+  toneHz: number; // lowpass frequency
+};
+
+export class OverdriveEffect extends SingleInOutEffect<OverdriveParams> {
+  private readonly shaper: WaveShaperNode;
+  private readonly postFilter: BiquadFilterNode;
+
+  constructor(ctx: AudioContext, opts: Partial<OverdriveParams> = {}) {
+    super(ctx, 'Overdrive', opts.mix ?? 0.5);
+    this.shaper = new WaveShaperNode(ctx, { oversample: '4x' });
+    this.postFilter = new BiquadFilterNode(ctx, {
+      type: 'lowpass',
+      frequency: 1200,
+    });
+    this.shaper.connect(this.postFilter);
+    this.initializeEffectCore(this.shaper, this.postFilter);
+    this.update({
+      drive: opts.drive ?? 0.75,
+      toneHz: opts.toneHz ?? 1200,
+      mix: opts.mix ?? 0.5,
+    });
+  }
+
+  update(params: Partial<OverdriveParams>) {
+    if (params.mix !== undefined) this.setMix(params.mix);
+
+    if (params.drive !== undefined) {
+      const drive = Math.max(0, Math.min(1.5, params.drive));
+      this.shaper.curve = createOverdriveCurve(drive);
+    }
+    if (params.toneHz !== undefined) {
+      this.postFilter.frequency.value = Math.max(20, params.toneHz);
+    }
+  }
+
+  remove() {
+    super.remove();
+  }
+}
+
+function createOverdriveCurve(drive: number) {
+  const samples = 2048;
+  const curve = new Float32Array(samples);
+  const k = drive * 100;
+  for (let i = 0; i < samples; i++) {
+    const x = (i / samples) * 2 - 1;
+    curve[i] = ((1 + k) * x) / (1 + k * Math.abs(x));
+  }
+  return curve;
+}
+
+

--- a/src/audio/effects/ReverbEffect.ts
+++ b/src/audio/effects/ReverbEffect.ts
@@ -1,0 +1,87 @@
+import { SingleInOutEffect } from './SingleInOutEffect';
+
+export type ReverbParams = {
+  mix: number; // 0..1
+  preDelayMs: number; // >= 0
+};
+
+export class ConvolverReverbEffect extends SingleInOutEffect<ReverbParams> {
+  private readonly convolver: ConvolverNode;
+  private preDelay?: DelayNode;
+
+  constructor(
+    ctx: AudioContext,
+    private impulseBuffer?: AudioBuffer,
+    opts: Partial<ReverbParams> = {}
+  ) {
+    super(ctx, 'Reverb', opts.mix ?? 0.3);
+    this.convolver = new ConvolverNode(ctx);
+    if (this.impulseBuffer) {
+      this.convolver.buffer = this.impulseBuffer;
+    } else {
+      // Provide a simple default impulse response so the effect is audible
+      this.convolver.buffer = createDefaultImpulseResponse(ctx, 2.0, 2.0);
+    }
+
+    // set up wet path depending on predelay
+    if (this.preDelay) {
+      this.preDelay.connect(this.convolver);
+      this.initializeEffectCore(this.preDelay, this.convolver);
+    } else {
+      this.initializeEffectCore(this.convolver, this.convolver);
+    }
+    this.update({
+      mix: opts.mix ?? 0.3,
+      preDelayMs: opts.preDelayMs ?? 0,
+    });
+  }
+
+  setImpulse(buffer: AudioBuffer) {
+    this.impulseBuffer = buffer;
+    if (this.convolver) this.convolver.buffer = buffer;
+  }
+
+  update(params: Partial<ReverbParams>) {
+    if (params.mix !== undefined) this.setMix(params.mix);
+
+    if (params.preDelayMs !== undefined) {
+      const value = Math.max(0, params.preDelayMs) / 1000;
+      if (!this.preDelay) {
+        this.preDelay = new DelayNode(this.audioContext, { delayTime: value });
+        // Rewire: split -> preDelay -> convolver
+        this.preDelay.connect(this.convolver);
+        this.initializeEffectCore(this.preDelay, this.convolver);
+      } else {
+        this.preDelay.delayTime.value = value;
+      }
+    }
+  }
+
+  remove() {
+    super.remove();
+    if (this.convolver) this.convolver.buffer = null;
+  }
+}
+
+function createDefaultImpulseResponse(
+  ctx: AudioContext,
+  durationSeconds = 1.5,
+  decay = 2.0,
+) {
+  const rate = ctx.sampleRate;
+  const length = Math.max(1, Math.floor(durationSeconds * rate));
+  const ir = ctx.createBuffer(2, length, rate);
+
+  for (let channel = 0; channel < ir.numberOfChannels; channel++) {
+    const data = ir.getChannelData(channel);
+    for (let i = 0; i < length; i++) {
+      // Exponential decay noise
+      const t = i / length;
+      data[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, decay);
+    }
+  }
+
+  return ir;
+}
+
+

--- a/src/audio/effects/SingleInOutEffect.ts
+++ b/src/audio/effects/SingleInOutEffect.ts
@@ -1,0 +1,97 @@
+import { AudioEffect } from "./AudioEffect";
+
+export abstract class SingleInOutEffect<P extends Record<string, unknown>>
+  implements AudioEffect<P>
+{
+  readonly name: string;
+
+  readonly input: GainNode;
+  readonly output: GainNode;
+
+  protected readonly splitGain: GainNode;
+  protected readonly dryGain: GainNode;
+  protected readonly wetGain: GainNode;
+  protected readonly sumGain: GainNode;
+
+  private bypassed = false;
+  private currentMix: number;
+  private readonly ctx: AudioContext;
+  private coreIn?: AudioNode;
+  private coreOut?: AudioNode;
+
+  constructor(ctx: AudioContext, name: string, initialMix = 0.5) {
+    this.ctx = ctx;
+    this.name = name;
+    this.currentMix = Math.min(1, Math.max(0, initialMix));
+
+    this.input = new GainNode(ctx);
+    this.output = new GainNode(ctx);
+
+    this.splitGain = new GainNode(ctx);
+    this.dryGain = new GainNode(ctx, { gain: 1 - this.currentMix });
+    this.wetGain = new GainNode(ctx, { gain: this.currentMix });
+    this.sumGain = new GainNode(ctx);
+
+    this.input.connect(this.splitGain);
+    this.splitGain.connect(this.dryGain);
+    this.dryGain.connect(this.sumGain);
+    this.sumGain.connect(this.output);
+
+    // Wet path will be wired by subclass via initializeEffectCore
+    this.wetGain.connect(this.sumGain);
+  }
+
+  protected get audioContext(): AudioContext {
+    return this.ctx;
+  }
+
+  /**
+   * Call this from the subclass constructor after creating the effect's core nodes
+   * to wire the wet path: split -> effectIn -> effectOut -> wet -> sum.
+   */
+  protected initializeEffectCore(effectInput: AudioNode, effectOutput: AudioNode) {
+    // Disconnect any previous wiring if re-initializing
+    if (this.coreIn) this.splitGain.disconnect(this.coreIn);
+    if (this.coreOut) this.coreOut.disconnect(this.wetGain);
+
+    this.coreIn = effectInput;
+    this.coreOut = effectOutput;
+
+    this.splitGain.connect(this.coreIn);
+    this.coreOut.connect(this.wetGain);
+  }
+
+  setMix(mix: number) {
+    const mixAmt = Math.min(1, Math.max(0, mix));
+    this.currentMix = mixAmt;
+    this.wetGain.gain.value = this.bypassed ? 0 : this.currentMix;
+    this.dryGain.gain.value = 1 - this.currentMix;
+  }
+
+  setBypassed(bypassed: boolean) {
+    this.bypassed = bypassed;
+    if (bypassed) {
+      this.wetGain.gain.value = 0;
+      this.dryGain.gain.value = 1;
+    } else {
+      // Restore wet/dry based on current mix when un-bypassing
+      this.wetGain.gain.value = this.currentMix;
+      this.dryGain.gain.value = 1 - this.currentMix;
+    }
+  }
+
+  // default no-op; subclasses override
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  update(_: Partial<P>) {}
+
+  remove() {
+    this.input.disconnect();
+    this.output.disconnect();
+    this.splitGain.disconnect();
+    this.dryGain.disconnect();
+    this.wetGain.disconnect();
+    this.sumGain.disconnect();
+    if (this.coreIn) this.coreIn.disconnect();
+    if (this.coreOut) this.coreOut.disconnect();
+  }
+}


### PR DESCRIPTION
Implements optional overdrive effect system as requested in # 22.

## Changes
- Created new effects directory with Overdrive class implementation
- Added overdrive support to Oscillator with setOverdrive/removeOverdrive methods
- Added overdrive support to Instrument to apply effects to all oscillators
- Exported overdrive classes from main package index
- Uses Max/MSP style overdrive with arctangent soft clipping and configurable drive

Closes # 22

Generated with [Claude Code](https://claude.ai/code)