### PR TITLE
Per-instrument control sections with tabbed interface

### DIFF
--- a/app/InstrumentControls.tsx
+++ b/app/InstrumentControls.tsx
@@ -133,18 +133,18 @@ export default function InstrumentControls({
 
   return (
     <div className="my-6">
-      <h3 className="text-lg font-semibold mb-3">Instrument Controls</h3>
+      <h3 className="text-lg font-semibold mb-3 text-white">Instrument Controls</h3>
       
       {/* Tab Navigation */}
-      <div className="flex border-b border-gray-300 mb-4">
+      <div className="flex border-b border-white/20 mb-4">
         {instruments.map((instrument) => (
           <button
             key={instrument}
             onClick={() => setActiveTab(instrument)}
             className={`px-4 py-2 font-medium text-sm capitalize transition-colors ${
               activeTab === instrument
-                ? "border-b-2 border-blue-500 text-blue-600 bg-blue-50"
-                : "text-gray-600 hover:text-gray-800 hover:bg-gray-50"
+                ? "border-b-2 border-white text-white bg-white/10"
+                : "text-white/70 hover:text-white hover:bg-white/5"
             }`}
           >
             {instrument}
@@ -153,13 +153,13 @@ export default function InstrumentControls({
       </div>
 
       {/* Current Instrument Control Panel */}
-      <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
-        <h4 className="text-md font-semibold mb-4 capitalize">{currentInstrument} Controls</h4>
+      <div className="p-4 border border-white/20 rounded-lg bg-black/40 backdrop-blur-sm">
+        <h4 className="text-md font-semibold mb-4 capitalize text-white">{currentInstrument} Controls</h4>
         
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Volume Control */}
           <div className="space-y-3">
-            <h5 className="text-sm font-medium text-gray-700">Volume</h5>
+            <h5 className="text-sm font-medium text-white/90">Volume</h5>
             <div className="flex items-center gap-4">
               <input
                 type="range"
@@ -168,9 +168,9 @@ export default function InstrumentControls({
                 step="0.01"
                 value={volumes[currentInstrument] || 1}
                 onChange={(e) => onVolumeChange(currentInstrument, parseFloat(e.target.value))}
-                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                className="flex-1 h-2 bg-white/20 rounded-lg appearance-none cursor-pointer"
               />
-              <div className="w-12 text-sm text-gray-600">
+              <div className="w-12 text-sm text-white/70">
                 {((volumes[currentInstrument] || 1) * 100).toFixed(0)}%
               </div>
             </div>
@@ -179,7 +179,7 @@ export default function InstrumentControls({
           {/* Filter Controls */}
           <div className="space-y-3">
             <div className="flex items-center justify-between">
-              <h5 className="text-sm font-medium text-gray-700">Filter</h5>
+              <h5 className="text-sm font-medium text-white/90">Filter</h5>
               <label className="flex items-center gap-2">
                 <input
                   type="checkbox"
@@ -187,7 +187,7 @@ export default function InstrumentControls({
                   onChange={(e) => onFilterChange(currentInstrument, "enabled", e.target.checked)}
                   className="form-checkbox"
                 />
-                <span className="text-xs text-gray-600">Enable</span>
+                <span className="text-xs text-white/70">Enable</span>
               </label>
             </div>
             
@@ -195,7 +195,7 @@ export default function InstrumentControls({
               <div className="space-y-2">
                 {/* Frequency */}
                 <div className="flex items-center gap-2">
-                  <div className="w-16 text-xs text-gray-600">Freq</div>
+                  <div className="w-16 text-xs text-white/70">Freq</div>
                   <input
                     type="range"
                     min="100"
@@ -203,14 +203,14 @@ export default function InstrumentControls({
                     step="100"
                     value={currentSettings.frequency}
                     onChange={(e) => onFilterChange(currentInstrument, "frequency", parseInt(e.target.value))}
-                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    className="flex-1 h-2 bg-white/20 rounded-lg appearance-none cursor-pointer"
                   />
-                  <div className="w-16 text-xs text-gray-600">{currentSettings.frequency}Hz</div>
+                  <div className="w-16 text-xs text-white/70">{currentSettings.frequency}Hz</div>
                 </div>
                 
                 {/* Q */}
                 <div className="flex items-center gap-2">
-                  <div className="w-16 text-xs text-gray-600">Q</div>
+                  <div className="w-16 text-xs text-white/70">Q</div>
                   <input
                     type="range"
                     min="0.1"
@@ -218,16 +218,16 @@ export default function InstrumentControls({
                     step="0.1"
                     value={currentSettings.Q}
                     onChange={(e) => onFilterChange(currentInstrument, "Q", parseFloat(e.target.value))}
-                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    className="flex-1 h-2 bg-white/20 rounded-lg appearance-none cursor-pointer"
                   />
-                  <div className="w-16 text-xs text-gray-600">{currentSettings.Q.toFixed(1)}</div>
+                  <div className="w-16 text-xs text-white/70">{currentSettings.Q.toFixed(1)}</div>
                 </div>
                 
                 {/* Type */}
                 <select
                   value={currentSettings.type}
                   onChange={(e) => onFilterChange(currentInstrument, "type", e.target.value as BiquadFilterType)}
-                  className="w-full px-2 py-1 text-xs border border-gray-300 rounded bg-white"
+                  className="w-full px-2 py-1 text-xs border border-white/30 rounded bg-black/50 text-white"
                 >
                   <option value="lowpass">Low Pass</option>
                   <option value="highpass">High Pass</option>
@@ -244,12 +244,12 @@ export default function InstrumentControls({
 
           {/* Effects Controls */}
           <div className="space-y-4">
-            <h5 className="text-sm font-medium text-gray-700">Effects</h5>
+            <h5 className="text-sm font-medium text-white/90">Effects</h5>
             
             {/* Overdrive */}
-            <div className="p-3 border border-gray-200 rounded bg-white">
+            <div className="p-3 border border-white/30 rounded bg-black/30">
               <div className="flex items-center justify-between mb-2">
-                <div className="text-xs font-medium">Overdrive</div>
+                <div className="text-xs font-medium text-white">Overdrive</div>
                 <label className="flex items-center gap-1">
                   <input
                     type="checkbox"
@@ -257,14 +257,14 @@ export default function InstrumentControls({
                     onChange={(e) => updateInstrumentOverdrive(currentInstrument, { enabled: e.target.checked })}
                     className="form-checkbox h-3 w-3"
                   />
-                  <span className="text-xs text-gray-600">On</span>
+                  <span className="text-xs text-white/70">On</span>
                 </label>
               </div>
               
               {currentEffects?.overdrive.enabled && (
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <div className="w-8 text-xs text-gray-600">Mix</div>
+                    <div className="w-8 text-xs text-white/70">Mix</div>
                     <input
                       type="range"
                       min="0"
@@ -272,14 +272,14 @@ export default function InstrumentControls({
                       step="0.01"
                       value={currentEffects.overdrive.params.mix}
                       onChange={(e) => updateInstrumentOverdrive(currentInstrument, { mix: parseFloat(e.target.value) })}
-                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                      className="flex-1 h-1 bg-white/20 rounded-lg appearance-none cursor-pointer"
                     />
-                    <div className="w-8 text-xs text-gray-600">
+                    <div className="w-8 text-xs text-white/70">
                       {(currentEffects.overdrive.params.mix * 100).toFixed(0)}%
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="w-8 text-xs text-gray-600">Drive</div>
+                    <div className="w-8 text-xs text-white/70">Drive</div>
                     <input
                       type="range"
                       min="0"
@@ -287,14 +287,14 @@ export default function InstrumentControls({
                       step="0.01"
                       value={currentEffects.overdrive.params.drive}
                       onChange={(e) => updateInstrumentOverdrive(currentInstrument, { drive: parseFloat(e.target.value) })}
-                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                      className="flex-1 h-1 bg-white/20 rounded-lg appearance-none cursor-pointer"
                     />
-                    <div className="w-8 text-xs text-gray-600">
+                    <div className="w-8 text-xs text-white/70">
                       {currentEffects.overdrive.params.drive.toFixed(2)}
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="w-8 text-xs text-gray-600">Tone</div>
+                    <div className="w-8 text-xs text-white/70">Tone</div>
                     <input
                       type="range"
                       min="100"
@@ -302,9 +302,9 @@ export default function InstrumentControls({
                       step="50"
                       value={currentEffects.overdrive.params.toneHz}
                       onChange={(e) => updateInstrumentOverdrive(currentInstrument, { toneHz: parseInt(e.target.value) })}
-                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                      className="flex-1 h-1 bg-white/20 rounded-lg appearance-none cursor-pointer"
                     />
-                    <div className="w-8 text-xs text-gray-600">
+                    <div className="w-8 text-xs text-white/70">
                       {currentEffects.overdrive.params.toneHz}Hz
                     </div>
                   </div>
@@ -313,9 +313,9 @@ export default function InstrumentControls({
             </div>
 
             {/* Reverb */}
-            <div className="p-3 border border-gray-200 rounded bg-white">
+            <div className="p-3 border border-white/30 rounded bg-black/30">
               <div className="flex items-center justify-between mb-2">
-                <div className="text-xs font-medium">Reverb</div>
+                <div className="text-xs font-medium text-white">Reverb</div>
                 <label className="flex items-center gap-1">
                   <input
                     type="checkbox"
@@ -323,14 +323,14 @@ export default function InstrumentControls({
                     onChange={(e) => updateInstrumentReverb(currentInstrument, { enabled: e.target.checked })}
                     className="form-checkbox h-3 w-3"
                   />
-                  <span className="text-xs text-gray-600">On</span>
+                  <span className="text-xs text-white/70">On</span>
                 </label>
               </div>
               
               {currentEffects?.reverb.enabled && (
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <div className="w-8 text-xs text-gray-600">Mix</div>
+                    <div className="w-8 text-xs text-white/70">Mix</div>
                     <input
                       type="range"
                       min="0"
@@ -338,14 +338,14 @@ export default function InstrumentControls({
                       step="0.01"
                       value={currentEffects.reverb.params.mix}
                       onChange={(e) => updateInstrumentReverb(currentInstrument, { mix: parseFloat(e.target.value) })}
-                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                      className="flex-1 h-1 bg-white/20 rounded-lg appearance-none cursor-pointer"
                     />
-                    <div className="w-8 text-xs text-gray-600">
+                    <div className="w-8 text-xs text-white/70">
                       {(currentEffects.reverb.params.mix * 100).toFixed(0)}%
                     </div>
                   </div>
                   <div className="flex items-center gap-2">
-                    <div className="w-8 text-xs text-gray-600">Pre</div>
+                    <div className="w-8 text-xs text-white/70">Pre</div>
                     <input
                       type="range"
                       min="0"
@@ -353,9 +353,9 @@ export default function InstrumentControls({
                       step="1"
                       value={currentEffects.reverb.params.preDelayMs}
                       onChange={(e) => updateInstrumentReverb(currentInstrument, { preDelayMs: parseInt(e.target.value) })}
-                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                      className="flex-1 h-1 bg-white/20 rounded-lg appearance-none cursor-pointer"
                     />
-                    <div className="w-8 text-xs text-gray-600">
+                    <div className="w-8 text-xs text-white/70">
                       {currentEffects.reverb.params.preDelayMs}ms
                     </div>
                   </div>

--- a/app/InstrumentControls.tsx
+++ b/app/InstrumentControls.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import React, { useState } from "react";
+import { FilterConfig } from "@/package/src/filter";
+import { OverdriveParams } from "@/package/src/effects/overdrive";
+import { ReverbParams } from "@/package/src/effects/reverb";
+import { Stage } from "@/package/src/stage";
+
+type InstrumentName = "kick" | "snare" | "hat" | "pinkHat";
+
+interface FilterSettings {
+  enabled: boolean;
+  frequency: number;
+  Q: number;
+  type: BiquadFilterType;
+}
+
+interface InstrumentControlsProps {
+  instruments: string[];
+  volumes: Record<string, number>;
+  filterSettings: Record<string, FilterSettings>;
+  stage: Stage | null;
+  onVolumeChange: (instrument: string, value: number) => void;
+  onFilterChange: (instrument: string, property: string, value: any) => void;
+}
+
+export default function InstrumentControls({
+  instruments,
+  volumes,
+  filterSettings,
+  stage,
+  onVolumeChange,
+  onFilterChange,
+}: InstrumentControlsProps) {
+  const [activeTab, setActiveTab] = useState<string>(instruments[0] || "kick");
+  
+  // Per-instrument effects state
+  const [instrumentEffects, setInstrumentEffects] = useState<Record<string, {
+    overdrive: { enabled: boolean; params: OverdriveParams };
+    reverb: { enabled: boolean; params: ReverbParams };
+  }>>(() => {
+    const initial: Record<string, any> = {};
+    instruments.forEach(instrument => {
+      initial[instrument] = {
+        overdrive: {
+          enabled: false,
+          params: { mix: 0.5, drive: 0.75, toneHz: 1200 }
+        },
+        reverb: {
+          enabled: false,
+          params: { mix: 0.25, preDelayMs: 20 }
+        }
+      };
+    });
+    return initial;
+  });
+
+  const updateInstrumentOverdrive = (instrument: string, updates: Partial<OverdriveParams> | { enabled: boolean }) => {
+    if ("enabled" in updates) {
+      const enabled = updates.enabled;
+      setInstrumentEffects(prev => ({
+        ...prev,
+        [instrument]: {
+          ...prev[instrument],
+          overdrive: { ...prev[instrument].overdrive, enabled }
+        }
+      }));
+      if (stage) {
+        stage.setInstrumentEffectBypassed(instrument, "Overdrive", !enabled);
+      }
+      return;
+    }
+    
+    setInstrumentEffects(prev => ({
+      ...prev,
+      [instrument]: {
+        ...prev[instrument],
+        overdrive: {
+          ...prev[instrument].overdrive,
+          params: { ...prev[instrument].overdrive.params, ...updates }
+        }
+      }
+    }));
+    
+    if (stage) {
+      const params: OverdriveParams = { 
+        ...instrumentEffects[instrument].overdrive.params, 
+        ...updates 
+      };
+      stage.updateInstrumentEffect(instrument, "Overdrive", params);
+    }
+  };
+
+  const updateInstrumentReverb = (instrument: string, updates: Partial<ReverbParams> | { enabled: boolean }) => {
+    if ("enabled" in updates) {
+      const enabled = updates.enabled;
+      setInstrumentEffects(prev => ({
+        ...prev,
+        [instrument]: {
+          ...prev[instrument],
+          reverb: { ...prev[instrument].reverb, enabled }
+        }
+      }));
+      if (stage) {
+        stage.setInstrumentEffectBypassed(instrument, "Reverb", !enabled);
+      }
+      return;
+    }
+    
+    setInstrumentEffects(prev => ({
+      ...prev,
+      [instrument]: {
+        ...prev[instrument],
+        reverb: {
+          ...prev[instrument].reverb,
+          params: { ...prev[instrument].reverb.params, ...updates }
+        }
+      }
+    }));
+    
+    if (stage) {
+      const params: ReverbParams = { 
+        ...instrumentEffects[instrument].reverb.params, 
+        ...updates 
+      };
+      stage.updateInstrumentEffect(instrument, "Reverb", params);
+    }
+  };
+
+  const currentInstrument = activeTab;
+  const currentSettings = filterSettings[currentInstrument];
+  const currentEffects = instrumentEffects[currentInstrument];
+
+  return (
+    <div className="my-6">
+      <h3 className="text-lg font-semibold mb-3">Instrument Controls</h3>
+      
+      {/* Tab Navigation */}
+      <div className="flex border-b border-gray-300 mb-4">
+        {instruments.map((instrument) => (
+          <button
+            key={instrument}
+            onClick={() => setActiveTab(instrument)}
+            className={`px-4 py-2 font-medium text-sm capitalize transition-colors ${
+              activeTab === instrument
+                ? "border-b-2 border-blue-500 text-blue-600 bg-blue-50"
+                : "text-gray-600 hover:text-gray-800 hover:bg-gray-50"
+            }`}
+          >
+            {instrument}
+          </button>
+        ))}
+      </div>
+
+      {/* Current Instrument Control Panel */}
+      <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
+        <h4 className="text-md font-semibold mb-4 capitalize">{currentInstrument} Controls</h4>
+        
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Volume Control */}
+          <div className="space-y-3">
+            <h5 className="text-sm font-medium text-gray-700">Volume</h5>
+            <div className="flex items-center gap-4">
+              <input
+                type="range"
+                min="0"
+                max="2"
+                step="0.01"
+                value={volumes[currentInstrument] || 1}
+                onChange={(e) => onVolumeChange(currentInstrument, parseFloat(e.target.value))}
+                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+              />
+              <div className="w-12 text-sm text-gray-600">
+                {((volumes[currentInstrument] || 1) * 100).toFixed(0)}%
+              </div>
+            </div>
+          </div>
+
+          {/* Filter Controls */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h5 className="text-sm font-medium text-gray-700">Filter</h5>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={currentSettings?.enabled || false}
+                  onChange={(e) => onFilterChange(currentInstrument, "enabled", e.target.checked)}
+                  className="form-checkbox"
+                />
+                <span className="text-xs text-gray-600">Enable</span>
+              </label>
+            </div>
+            
+            {currentSettings?.enabled && (
+              <div className="space-y-2">
+                {/* Frequency */}
+                <div className="flex items-center gap-2">
+                  <div className="w-16 text-xs text-gray-600">Freq</div>
+                  <input
+                    type="range"
+                    min="100"
+                    max="20000"
+                    step="100"
+                    value={currentSettings.frequency}
+                    onChange={(e) => onFilterChange(currentInstrument, "frequency", parseInt(e.target.value))}
+                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  />
+                  <div className="w-16 text-xs text-gray-600">{currentSettings.frequency}Hz</div>
+                </div>
+                
+                {/* Q */}
+                <div className="flex items-center gap-2">
+                  <div className="w-16 text-xs text-gray-600">Q</div>
+                  <input
+                    type="range"
+                    min="0.1"
+                    max="10"
+                    step="0.1"
+                    value={currentSettings.Q}
+                    onChange={(e) => onFilterChange(currentInstrument, "Q", parseFloat(e.target.value))}
+                    className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  />
+                  <div className="w-16 text-xs text-gray-600">{currentSettings.Q.toFixed(1)}</div>
+                </div>
+                
+                {/* Type */}
+                <select
+                  value={currentSettings.type}
+                  onChange={(e) => onFilterChange(currentInstrument, "type", e.target.value as BiquadFilterType)}
+                  className="w-full px-2 py-1 text-xs border border-gray-300 rounded bg-white"
+                >
+                  <option value="lowpass">Low Pass</option>
+                  <option value="highpass">High Pass</option>
+                  <option value="bandpass">Band Pass</option>
+                  <option value="notch">Notch</option>
+                  <option value="allpass">All Pass</option>
+                  <option value="peaking">Peaking</option>
+                  <option value="lowshelf">Low Shelf</option>
+                  <option value="highshelf">High Shelf</option>
+                </select>
+              </div>
+            )}
+          </div>
+
+          {/* Effects Controls */}
+          <div className="space-y-4">
+            <h5 className="text-sm font-medium text-gray-700">Effects</h5>
+            
+            {/* Overdrive */}
+            <div className="p-3 border border-gray-200 rounded bg-white">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-xs font-medium">Overdrive</div>
+                <label className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={currentEffects?.overdrive.enabled || false}
+                    onChange={(e) => updateInstrumentOverdrive(currentInstrument, { enabled: e.target.checked })}
+                    className="form-checkbox h-3 w-3"
+                  />
+                  <span className="text-xs text-gray-600">On</span>
+                </label>
+              </div>
+              
+              {currentEffects?.overdrive.enabled && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 text-xs text-gray-600">Mix</div>
+                    <input
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={currentEffects.overdrive.params.mix}
+                      onChange={(e) => updateInstrumentOverdrive(currentInstrument, { mix: parseFloat(e.target.value) })}
+                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    />
+                    <div className="w-8 text-xs text-gray-600">
+                      {(currentEffects.overdrive.params.mix * 100).toFixed(0)}%
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 text-xs text-gray-600">Drive</div>
+                    <input
+                      type="range"
+                      min="0"
+                      max="1.5"
+                      step="0.01"
+                      value={currentEffects.overdrive.params.drive}
+                      onChange={(e) => updateInstrumentOverdrive(currentInstrument, { drive: parseFloat(e.target.value) })}
+                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    />
+                    <div className="w-8 text-xs text-gray-600">
+                      {currentEffects.overdrive.params.drive.toFixed(2)}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 text-xs text-gray-600">Tone</div>
+                    <input
+                      type="range"
+                      min="100"
+                      max="8000"
+                      step="50"
+                      value={currentEffects.overdrive.params.toneHz}
+                      onChange={(e) => updateInstrumentOverdrive(currentInstrument, { toneHz: parseInt(e.target.value) })}
+                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    />
+                    <div className="w-8 text-xs text-gray-600">
+                      {currentEffects.overdrive.params.toneHz}Hz
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Reverb */}
+            <div className="p-3 border border-gray-200 rounded bg-white">
+              <div className="flex items-center justify-between mb-2">
+                <div className="text-xs font-medium">Reverb</div>
+                <label className="flex items-center gap-1">
+                  <input
+                    type="checkbox"
+                    checked={currentEffects?.reverb.enabled || false}
+                    onChange={(e) => updateInstrumentReverb(currentInstrument, { enabled: e.target.checked })}
+                    className="form-checkbox h-3 w-3"
+                  />
+                  <span className="text-xs text-gray-600">On</span>
+                </label>
+              </div>
+              
+              {currentEffects?.reverb.enabled && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 text-xs text-gray-600">Mix</div>
+                    <input
+                      type="range"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={currentEffects.reverb.params.mix}
+                      onChange={(e) => updateInstrumentReverb(currentInstrument, { mix: parseFloat(e.target.value) })}
+                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    />
+                    <div className="w-8 text-xs text-gray-600">
+                      {(currentEffects.reverb.params.mix * 100).toFixed(0)}%
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 text-xs text-gray-600">Pre</div>
+                    <input
+                      type="range"
+                      min="0"
+                      max="200"
+                      step="1"
+                      value={currentEffects.reverb.params.preDelayMs}
+                      onChange={(e) => updateInstrumentReverb(currentInstrument, { preDelayMs: parseInt(e.target.value) })}
+                      className="flex-1 h-1 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                    />
+                    <div className="w-8 text-xs text-gray-600">
+                      {currentEffects.reverb.params.preDelayMs}ms
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,22 +224,39 @@ export default function ReactTestPage() {
     if (ctx && stage && !sequencerRef.current) {
       const startTime = ctx.currentTime;
 
-      // Create instruments without filter configs initially
-      const kick = makeKick(ctx, 50, 300);
+      // Create instruments with effects chains for UI control
+      const kick = makeKick(ctx, 50, 300, {
+        effects: {
+          overdrive: { mix: 0.5, drive: 0.75, toneHz: 1200, enabled: false },
+          reverb: { mix: 0.25, preDelayMs: 20, enabled: false }
+        }
+      });
       stage.addInstrument("kick", kick);
 
       const snare = makeSnare(ctx, 400, 800, {
         decay_time: 0.3,
+        effects: {
+          overdrive: { mix: 0.5, drive: 0.75, toneHz: 1200, enabled: false },
+          reverb: { mix: 0.25, preDelayMs: 20, enabled: false }
+        }
       });
       stage.addInstrument("snare", snare);
 
       const hat = makeSnare(ctx, 200, 800, {
         decay_time: 0.1,
+        effects: {
+          overdrive: { mix: 0.5, drive: 0.75, toneHz: 1200, enabled: false },
+          reverb: { mix: 0.25, preDelayMs: 20, enabled: false }
+        }
       });
       stage.addInstrument("hat", hat);
 
       const pinkHat = makePinkHat(ctx, {
         decay_time: 0.1,
+        effects: {
+          overdrive: { mix: 0.5, drive: 0.75, toneHz: 1200, enabled: false },
+          reverb: { mix: 0.25, preDelayMs: 20, enabled: false }
+        }
       });
       stage.addInstrument("pinkHat", pinkHat);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,7 @@ import { makePinkHat } from "@/package/src/pink-hat";
 import { Sequencer } from "@/package/src/sequencer";
 import { useBeatTracker } from "@/package/src/hooks";
 import { FilterConfig } from "@/package/src/filter";
-import { OverdriveParams } from "@/package/src/effects/overdrive";
-import { ReverbParams } from "@/package/src/effects/reverb";
+import InstrumentControls from "./InstrumentControls";
 
 export default function ReactTestPage() {
   const [patterns, setPatterns] = useState({
@@ -150,92 +149,18 @@ export default function ReactTestPage() {
     }
   };
 
-  // ==== Effects: state and helpers ====
-  const [overdriveSettings, setOverdriveSettings] = useState<{
-    enabled: boolean;
-    params: OverdriveParams;
-  }>({
-    enabled: false,
-    params: { mix: 0.5, drive: 0.75, toneHz: 1200 },
-  });
-
-  const [reverbSettings, setReverbSettings] = useState<{
-    enabled: boolean;
-    params: ReverbParams;
-  }>({
-    enabled: false,
-    params: { mix: 0.25, preDelayMs: 20 },
-  });
-
-  const updateOverdrive = (updates: Partial<OverdriveParams> | { enabled: boolean }) => {
-    if ("enabled" in updates) {
-      const enabled = updates.enabled;
-      setOverdriveSettings((prev) => ({ ...prev, enabled }));
-      // Propagate bypass to existing instruments
-      if (stage) {
-        ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-          stage.setInstrumentEffectBypassed(name, "Overdrive", !enabled),
-        );
-      }
-      return;
-    }
-    setOverdriveSettings((prev) => ({
-      ...prev,
-      params: { ...prev.params, ...updates },
-    }));
-    // Propagate param changes
-    if (stage) {
-      const params: OverdriveParams = { ...overdriveSettings.params, ...updates };
-      ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-        stage.updateInstrumentEffect(name, "Overdrive", params),
-      );
-    }
-  };
-
-  const updateReverb = (updates: Partial<ReverbParams> | { enabled: boolean }) => {
-    if ("enabled" in updates) {
-      const enabled = updates.enabled;
-      setReverbSettings((prev) => ({ ...prev, enabled }));
-      if (stage) {
-        ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-          stage.setInstrumentEffectBypassed(name, "Reverb", !enabled),
-        );
-      }
-      return;
-    }
-    setReverbSettings((prev) => ({
-      ...prev,
-      params: { ...prev.params, ...updates },
-    }));
-    if (stage) {
-      const params: ReverbParams = { ...reverbSettings.params, ...updates };
-      ["kick", "kick2", "snare", "hat", "pinkHat"].forEach((name) =>
-        stage.updateInstrumentEffect(name, "Reverb", params),
-      );
-    }
-  };
 
   const triggerKick = () => {
     const ctx = audioContext;
     if (ctx && stage) {
       // Create instruments if they don't exist
       if (!stage.hasInstrument("kick")) {
-        const kick1 = makeKick(ctx, 200, 800, {
-          effects: {
-            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-          },
-        });
+        const kick1 = makeKick(ctx, 200, 800);
         stage.addInstrument("kick", kick1);
       }
 
       if (!stage.hasInstrument("kick2")) {
-        const kick2 = makeKick(ctx, 1500, 2000, {
-          effects: {
-            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-          },
-        });
+        const kick2 = makeKick(ctx, 1500, 2000);
         stage.addInstrument("kick2", kick2);
       }
 
@@ -260,10 +185,6 @@ export default function ReactTestPage() {
       if (!stage.hasInstrument("snare")) {
         const snare1 = makeSnare(ctx, 200, 800, {
           decay_time: 0.3,
-          effects: {
-            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-          },
         });
         stage.addInstrument("snare", snare1);
       }
@@ -285,10 +206,6 @@ export default function ReactTestPage() {
       if (!stage.hasInstrument("pinkHat")) {
         const pinkHat1 = makePinkHat(ctx, {
           decay_time: 0.12,
-          effects: {
-            overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-            reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-          },
         });
         stage.addInstrument("pinkHat", pinkHat1);
       }
@@ -308,38 +225,21 @@ export default function ReactTestPage() {
       const startTime = ctx.currentTime;
 
       // Create instruments without filter configs initially
-      const kick = makeKick(ctx, 50, 300, {
-        effects: {
-          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-        },
-      });
+      const kick = makeKick(ctx, 50, 300);
       stage.addInstrument("kick", kick);
 
       const snare = makeSnare(ctx, 400, 800, {
         decay_time: 0.3,
-        effects: {
-          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-        },
       });
       stage.addInstrument("snare", snare);
 
       const hat = makeSnare(ctx, 200, 800, {
         decay_time: 0.1,
-        effects: {
-          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-        },
       });
       stage.addInstrument("hat", hat);
 
       const pinkHat = makePinkHat(ctx, {
         decay_time: 0.1,
-        effects: {
-          overdrive: { ...overdriveSettings.params, enabled: overdriveSettings.enabled },
-          reverb: { ...reverbSettings.params, enabled: reverbSettings.enabled },
-        },
       });
       stage.addInstrument("pinkHat", pinkHat);
 
@@ -468,119 +368,14 @@ export default function ReactTestPage() {
         </button>
       </div>
 
-      <div className="my-6">
-        <h3 className="text-lg font-semibold mb-3">Master Effects</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Overdrive */}
-          <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
-            <div className="flex items-center justify-between mb-3">
-              <div className="font-medium">Overdrive</div>
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={overdriveSettings.enabled}
-                  onChange={(e) => updateOverdrive({ enabled: e.target.checked })}
-                />
-                <span className="text-sm text-gray-600">Enable</span>
-              </label>
-            </div>
-            <div className="space-y-3">
-              <div className="flex items-center gap-4">
-                <div className="w-20 text-xs text-gray-600">Mix</div>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.01"
-                  value={overdriveSettings.params.mix}
-                  onChange={(e) => updateOverdrive({ mix: parseFloat(e.target.value) })}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <div className="w-16 text-xs text-gray-600">
-                  {(overdriveSettings.params.mix * 100).toFixed(0)}%
-                </div>
-              </div>
-              <div className="flex items-center gap-4">
-                <div className="w-20 text-xs text-gray-600">Drive</div>
-                <input
-                  type="range"
-                  min="0"
-                  max="1.5"
-                  step="0.01"
-                  value={overdriveSettings.params.drive}
-                  onChange={(e) => updateOverdrive({ drive: parseFloat(e.target.value) })}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <div className="w-16 text-xs text-gray-600">
-                  {overdriveSettings.params.drive.toFixed(2)}
-                </div>
-              </div>
-              <div className="flex items-center gap-4">
-                <div className="w-20 text-xs text-gray-600">Tone Hz</div>
-                <input
-                  type="range"
-                  min="100"
-                  max="8000"
-                  step="50"
-                  value={overdriveSettings.params.toneHz}
-                  onChange={(e) => updateOverdrive({ toneHz: parseInt(e.target.value) })}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <div className="w-16 text-xs text-gray-600">
-                  {overdriveSettings.params.toneHz}Hz
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Reverb */}
-          <div className="p-4 border border-gray-300 rounded-lg bg-gray-50">
-            <div className="flex items-center justify-between mb-3">
-              <div className="font-medium">Reverb</div>
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={reverbSettings.enabled}
-                  onChange={(e) => updateReverb({ enabled: e.target.checked })}
-                />
-                <span className="text-sm text-gray-600">Enable</span>
-              </label>
-            </div>
-            <div className="space-y-3">
-              <div className="flex items-center gap-4">
-                <div className="w-20 text-xs text-gray-600">Mix</div>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.01"
-                  value={reverbSettings.params.mix}
-                  onChange={(e) => updateReverb({ mix: parseFloat(e.target.value) })}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <div className="w-16 text-xs text-gray-600">
-                  {(reverbSettings.params.mix * 100).toFixed(0)}%
-                </div>
-              </div>
-              <div className="flex items-center gap-4">
-                <div className="w-20 text-xs text-gray-600">PreDelay</div>
-                <input
-                  type="range"
-                  min="0"
-                  max="200"
-                  step="1"
-                  value={reverbSettings.params.preDelayMs}
-                  onChange={(e) => updateReverb({ preDelayMs: parseInt(e.target.value) })}
-                  className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                />
-                <div className="w-16 text-xs text-gray-600">
-                  {reverbSettings.params.preDelayMs}ms
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <InstrumentControls
+        instruments={instruments}
+        volumes={volumes}
+        filterSettings={filterSettings}
+        stage={stage}
+        onVolumeChange={handleVolumeChange}
+        onFilterChange={handleFilterChange}
+      />
       <div className="my-6">
         <h3 className="text-lg font-semibold mb-3">Sequencer Pattern</h3>
         <div className="space-y-2">
@@ -654,167 +449,23 @@ export default function ReactTestPage() {
       </div>
 
       <div className="my-6">
-        <h3 className="text-lg font-semibold mb-3">Volume Controls</h3>
-        <div className="space-y-3">
-          {/* Master Volume */}
-          <div className="flex items-center gap-4">
-            <div className="w-16 text-sm font-medium text-gray-700">Master</div>
-            <input
-              type="range"
-              min="0"
-              max="2"
-              step="0.01"
-              value={volumes.master}
-              onChange={(e) =>
-                handleVolumeChange("master", parseFloat(e.target.value))
-              }
-              className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-            />
-            <div className="w-12 text-sm text-gray-600">
-              {(volumes.master * 100).toFixed(0)}%
-            </div>
+        <h3 className="text-lg font-semibold mb-3">Master Volume</h3>
+        <div className="flex items-center gap-4">
+          <div className="w-16 text-sm font-medium text-gray-700">Master</div>
+          <input
+            type="range"
+            min="0"
+            max="2"
+            step="0.01"
+            value={volumes.master}
+            onChange={(e) =>
+              handleVolumeChange("master", parseFloat(e.target.value))
+            }
+            className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+          />
+          <div className="w-12 text-sm text-gray-600">
+            {(volumes.master * 100).toFixed(0)}%
           </div>
-
-          {/* Instrument Volumes */}
-          {instruments.map((instrument) => (
-            <div key={instrument} className="flex items-center gap-4">
-              <div className="w-16 text-sm font-medium text-gray-700 capitalize">
-                {instrument}
-              </div>
-              <input
-                type="range"
-                min="0"
-                max="2"
-                step="0.01"
-                value={volumes[instrument as keyof typeof volumes]}
-                onChange={(e) =>
-                  handleVolumeChange(instrument, parseFloat(e.target.value))
-                }
-                className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-              />
-              <div className="w-12 text-sm text-gray-600">
-                {(volumes[instrument as keyof typeof volumes] * 100).toFixed(0)}
-                %
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="my-6">
-        <h3 className="text-lg font-semibold mb-3">Filter Controls</h3>
-        <div className="space-y-4">
-          {instruments.map((instrument) => {
-            const settings =
-              filterSettings[instrument as keyof typeof filterSettings];
-
-            return (
-              <div
-                key={instrument}
-                className="p-4 border border-gray-300 rounded-lg bg-gray-50"
-              >
-                <div className="flex items-center gap-4 mb-3">
-                  <div className="w-16 text-sm font-medium text-gray-700 capitalize">
-                    {instrument}
-                  </div>
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={settings.enabled}
-                      onChange={(e) =>
-                        handleFilterChange(
-                          instrument,
-                          "enabled",
-                          e.target.checked
-                        )
-                      }
-                      className="form-checkbox"
-                    />
-                    <span className="text-sm text-gray-600">Enable Filter</span>
-                  </label>
-                </div>
-
-                {settings.enabled && (
-                  <div className="space-y-3">
-                    {/* Frequency Control */}
-                    <div className="flex items-center gap-4">
-                      <div className="w-20 text-xs text-gray-600">
-                        Frequency
-                      </div>
-                      <input
-                        type="range"
-                        min="100"
-                        max="20000"
-                        step="100"
-                        value={settings.frequency}
-                        onChange={(e) =>
-                          handleFilterChange(
-                            instrument,
-                            "frequency",
-                            parseInt(e.target.value)
-                          )
-                        }
-                        className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                      />
-                      <div className="w-16 text-xs text-gray-600">
-                        {settings.frequency}Hz
-                      </div>
-                    </div>
-
-                    {/* Q (Resonance) Control */}
-                    <div className="flex items-center gap-4">
-                      <div className="w-20 text-xs text-gray-600">
-                        Resonance
-                      </div>
-                      <input
-                        type="range"
-                        min="0.1"
-                        max="10"
-                        step="0.1"
-                        value={settings.Q}
-                        onChange={(e) =>
-                          handleFilterChange(
-                            instrument,
-                            "Q",
-                            parseFloat(e.target.value)
-                          )
-                        }
-                        className="flex-1 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer"
-                      />
-                      <div className="w-16 text-xs text-gray-600">
-                        {settings.Q.toFixed(1)}
-                      </div>
-                    </div>
-
-                    {/* Filter Type Control */}
-                    <div className="flex items-center gap-4">
-                      <div className="w-20 text-xs text-gray-600">Type</div>
-                      <select
-                        value={settings.type}
-                        onChange={(e) =>
-                          handleFilterChange(
-                            instrument,
-                            "type",
-                            e.target.value as BiquadFilterType
-                          )
-                        }
-                        className="flex-1 px-2 py-1 text-xs border border-gray-300 rounded bg-white"
-                      >
-                        <option value="lowpass">Low Pass</option>
-                        <option value="highpass">High Pass</option>
-                        <option value="bandpass">Band Pass</option>
-                        <option value="notch">Notch</option>
-                        <option value="allpass">All Pass</option>
-                        <option value="peaking">Peaking</option>
-                        <option value="lowshelf">Low Shelf</option>
-                        <option value="highshelf">High Shelf</option>
-                      </select>
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
         </div>
       </div>
 


### PR DESCRIPTION
Implements per-instrument control sections with tabbed interface as requested in #[24].

Changes:
- Create InstrumentControls.tsx component with tabbed interface
- Add per-instrument volume, filter, and effects controls
- Remove global master effects in favor of per-instrument settings
- Keep master volume control separate
- Organize UI with tabs for kick, snare, hat, pinkHat instruments

Generated with [Claude Code](https://claude.ai/code)