### PR TITLE
Add spacebar toggle for sequencer start/stop

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { useLibGooey } from "@/package/src/libgooey";
 import { makeKick } from "@/package/src/kick";
 import { makeSnare } from "@/package/src/snare";
@@ -67,6 +67,30 @@ export default function ReactTestPage() {
     audioContext,
     sequencerRef,
   });
+
+  // Handle spacebar key press to start/stop sequencer
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.code === 'Space') {
+        event.preventDefault(); // Prevent default spacebar behavior (page scroll)
+        
+        if (sequencerRef.current) {
+          stopSequencer();
+        } else {
+          startSequencer();
+        }
+      }
+    };
+
+    // Only add event listener if audio is loaded
+    if (isLoaded) {
+      window.addEventListener('keydown', handleKeyPress);
+    }
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [isLoaded, sequencerRef.current, startSequencer, stopSequencer]);
 
   const handleInitialize = async () => {
     await initialize();


### PR DESCRIPTION
Add keyboard event handler for spacebar key press to toggle between starting and stopping the sequencer.

- Add spacebar key handler with useEffect
- Toggle between starting and stopping sequencer with spacebar
- Prevent default spacebar behavior (page scroll)
- Only activate when audio engine is loaded

Closes #28

Generated with [Claude Code](https://claude.ai/code)