### PR TITLE
Add spacebar toggle for sequencer start/stop

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -420,6 +420,30 @@ export default function ReactTestPage() {
     });
   };
 
+  // Spacebar key handler for start/stop sequencer
+  useEffect(() => {
+    if (!isLoaded) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Only trigger on spacebar and when not typing in an input field
+      if (event.code === 'Space' && event.target === document.body) {
+        event.preventDefault(); // Prevent page scroll
+        
+        if (sequencerRef.current) {
+          stopSequencer();
+        } else {
+          startSequencer();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isLoaded, sequencerRef]);
+
   if (isLoading || instrumentsLoading) {
     return (
       <div className="p-8">


### PR DESCRIPTION
Add keyboard event handler for spacebar key press to toggle between starting and stopping the sequencer.

- Add spacebar key handler with useEffect
- Toggle between starting and stopping sequencer with spacebar
- Prevent default spacebar behavior (page scroll)
- Only activate when audio engine is loaded and focus is on document body
- Properly clean up event listeners on component unmount

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)